### PR TITLE
fix legacy image props

### DIFF
--- a/apps/web/src/components/hero/index.tsx
+++ b/apps/web/src/components/hero/index.tsx
@@ -25,13 +25,11 @@ export function Hero({ images, text }: { images: string[]; text: string }) {
         <Image
           alt=""
           className={cn(
-            "z-10 transition-opacity duration-1000",
+            "z-10 object-cover object-center transition-opacity duration-1000",
             imageIndex === currentImage ? "opacity-25" : "opacity-0",
           )}
+          fill
           key={image}
-          layout="fill"
-          objectFit="cover"
-          objectPosition="center"
           priority
           src={image}
         />


### PR DESCRIPTION
Fixes:
```
web:dev: Image with src "/media/landari-laskiaisrieha.jpg" has legacy prop "layout". Did you forget to run the codemod?
web:dev: Read more: https://nextjs.org/docs/messages/next-image-upgrade-to-13
web:dev: Image with src "/media/landari-laskiaisrieha.jpg" has legacy prop "objectFit". Did you forget to run the codemod?
web:dev: Read more: https://nextjs.org/docs/messages/next-image-upgrade-to-13
web:dev: Image with src "/media/landari-laskiaisrieha.jpg" has legacy prop "objectPosition". Did you forget to run the codemod?
web:dev: Read more: https://nextjs.org/docs/messages/next-image-upgrade-to-13
web:dev: Image with src "/media/landari-otatarhanajot.jpg" has legacy prop "layout". Did you forget to run the codemod?
web:dev: Read more: https://nextjs.org/docs/messages/next-image-upgrade-to-13
web:dev: Image with src "/media/landari-otatarhanajot.jpg" has legacy prop "objectFit". Did you forget to run the codemod?
web:dev: Read more: https://nextjs.org/docs/messages/next-image-upgrade-to-13
web:dev: Image with src "/media/landari-otatarhanajot.jpg" has legacy prop "objectPosition". Did you forget to run the codemod?
```