### PR TITLE
Fix issue with mobile navigation cutting off from the bottom

### DIFF
--- a/apps/web/src/components/mobile-nav/index.tsx
+++ b/apps/web/src/components/mobile-nav/index.tsx
@@ -59,7 +59,7 @@ export async function MobileNav({
           </Button>
         </SheetTrigger>
         <SheetContent>
-          <nav>
+          <nav className="flex h-full flex-col">
             <LanguageSelector />
             <LinkList footerLinks={footerLinks} links={links} />
           </nav>

--- a/apps/web/src/components/mobile-nav/link-list.tsx
+++ b/apps/web/src/components/mobile-nav/link-list.tsx
@@ -99,7 +99,7 @@ export function LinkList({
   footerLinks: LinkRowBlock[];
 }) {
   return (
-    <div className="h-[100lvh] overflow-y-auto font-mono text-xl font-semibold text-gray-900">
+    <div className="overflow-y-auto font-mono text-xl font-semibold text-gray-900">
       <ul className="mt-6 flex flex-col gap-6 p-4">
         {links.map((pageOrTopic) => (
           <li key={pageOrTopic.id}>
@@ -108,7 +108,7 @@ export function LinkList({
         ))}
       </ul>
       <Separator className="my-2" />
-      <ul className="mb-16 space-y-6 p-6">
+      <ul className="mb-8 space-y-6 p-6">
         {footerLinks.map((linkRow) => (
           <li key={linkRow.id}>
             <ul


### PR DESCRIPTION
Due to `vh` units being absolute shit, they don't handle things like address bars properly. There's `dvh` unit available, but from my experience it's just better to have a flex container with 100% height. See images below for before/after when scrolling to the absolute bottom of navigation bar.

Before:

![image](https://github.com/Tietokilta/web/assets/16230831/a4313847-b9c4-492f-a77f-01aa7b0bf258)

After:

![image](https://github.com/Tietokilta/web/assets/16230831/a1d02d52-7c7b-4802-873e-47a9845198f1)
