### PR TITLE
append random slug to page path if duplicate, make paths unique

### DIFF
--- a/apps/cms/package.json
+++ b/apps/cms/package.json
@@ -27,6 +27,7 @@
     "dotenv": "^16.4.5",
     "express": "^4.19.2",
     "lodash": "^4.17.21",
+    "nanoid": "^3.3.7",
     "papaparse": "^5.4.1",
     "payload": "^2.16.1",
     "payload-plugin-oauth": "^2.1.1"

--- a/apps/cms/src/util/index.ts
+++ b/apps/cms/src/util/index.ts
@@ -23,3 +23,21 @@ export function getLocale(req: PayloadRequest): string | undefined {
   }
   return res;
 }
+
+export function appendToStringOrLocalizedString(
+  str: string | null | undefined | Record<string, string | null | undefined>,
+  append: string,
+): string | Record<string, string> {
+  if (!str) {
+    return "";
+  }
+
+  if (typeof str === "string") {
+    return `${str}${append}`;
+  }
+  const res: Record<string, string> = {};
+  for (const locale in str) {
+    res[locale] = `${str[locale] ?? ""}${append}`;
+  }
+  return res;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,6 +52,9 @@ importers:
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
+      nanoid:
+        specifier: ^3.3.7
+        version: 3.3.7
       papaparse:
         specifier: ^5.4.1
         version: 5.4.1


### PR DESCRIPTION
Better than blocking creating altogether, append a short nanoid to the end

Closes #294 