### PR TITLE
fix: covers of alkorytmi with different aspect ratio

### DIFF
--- a/apps/web/src/components/magazine-list/index.tsx
+++ b/apps/web/src/components/magazine-list/index.tsx
@@ -16,7 +16,6 @@ function IssueCard({ issue }: { issue: MagazineIssue }) {
       <a href={file.url ?? ""}>
         <Image
           alt={thumbnail.alt}
-          className="aspect-[1/1.41] w-full object-contain object-bottom"
           height={thumbnail.height ?? undefined}
           src={thumbnail.url ?? TikLogo}
           width={thumbnail.width ?? undefined}
@@ -58,7 +57,7 @@ export function MagazineList({
             <span className="self-center text-sm font-medium">{year}</span>
             <div className="w-5" />
           </div>
-          <div className="grid max-w-64 grid-cols-1 gap-8 min-[460px]:max-w-none min-[460px]:grid-cols-2 min-[660px]:grid-cols-3 lg:grid-cols-4">
+          <div className="grid max-w-64 grid-cols-1 items-baseline gap-8 min-[460px]:max-w-none min-[460px]:grid-cols-2 min-[660px]:grid-cols-3 lg:grid-cols-4">
             {issuesByYear[year]
               .sort(
                 (a, b) =>


### PR DESCRIPTION
## Description

Currently there are sometimes unnecessary space if there are some covers of Alkorytmi that have weird aspect ratio:
![image](https://github.com/user-attachments/assets/5075ccda-6e7f-4f23-bd98-f64daf04ab8b)

This PR makes it look like this:
![image](https://github.com/user-attachments/assets/d4524b1a-476b-438a-9667-3081aa5469d7)
![image](https://github.com/user-attachments/assets/9ceea4e4-cc04-4173-b194-cd3165415980)

### Before submitting the PR, please make sure you do the following

- [ ] If your PR is related to a previously discussed issue, please [link to it](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue) here.
- [x] Prefix your PR title with feat:, fix:, chore:, or docs:.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Make sure the commit history is linear, up-to-date with main branch and does not contain any erroneous changes

### Formatting and linting

- [x] Format code with `pnpm format` and lint the project with `pnpm lint`
