### PR TITLE
Signup not found page

### DIFF
--- a/apps/web/src/app/[locale]/[...path]/page.tsx
+++ b/apps/web/src/app/[locale]/[...path]/page.tsx
@@ -142,7 +142,7 @@ async function Page({ params: { path } }: Props) {
         id="main"
         className="relative mb-8 flex flex-col items-center gap-2 md:gap-6"
       >
-        <header className="flex h-[15svh] w-full items-center justify-center bg-gray-900 text-gray-100 md:h-[25svh]">
+        <header className="flex h-[15svh] w-full items-center justify-center bg-gray-900 p-2 text-gray-100 md:h-[25svh]">
           <h1 className="font-mono text-4xl md:text-5xl">{page.title}</h1>
         </header>
 

--- a/apps/web/src/app/[locale]/error.tsx
+++ b/apps/web/src/app/[locale]/error.tsx
@@ -18,7 +18,7 @@ function Error({
 
   return (
     <main className="relative mb-8 flex flex-col items-center gap-2 md:gap-6">
-      <header className="flex h-[15svh] w-full items-center justify-center bg-gray-900 text-gray-100 md:h-[25svh]">
+      <header className="flex h-[15svh] w-full items-center justify-center bg-gray-900 p-2 text-gray-100 md:h-[25svh]">
         <h1 className="font-mono text-4xl md:text-5xl">
           {t("Jotain meni pieleen")}
         </h1>

--- a/apps/web/src/app/[locale]/global-error.tsx
+++ b/apps/web/src/app/[locale]/global-error.tsx
@@ -22,7 +22,7 @@ function GlobalError({
           id="main"
           className="relative mb-8 flex flex-col items-center gap-2 md:gap-6"
         >
-          <header className="flex h-[15svh] w-full items-center justify-center bg-gray-900 text-gray-100 md:h-[25svh]">
+          <header className="flex h-[15svh] w-full items-center justify-center bg-gray-900 p-2 text-gray-100 md:h-[25svh]">
             <h1 className="font-mono text-4xl md:text-5xl">
               {t("Jotain meni pieleen")}
             </h1>

--- a/apps/web/src/app/[locale]/not-found.tsx
+++ b/apps/web/src/app/[locale]/not-found.tsx
@@ -15,7 +15,7 @@ function Page() {
       id="main"
       className="relative mb-8 flex flex-col items-center gap-2 md:gap-6"
     >
-      <header className="flex h-[15svh] w-full items-center justify-center bg-gray-900 text-gray-100 md:h-[25svh]">
+      <header className="flex h-[15svh] w-full items-center justify-center bg-gray-900 p-2 text-gray-100 md:h-[25svh]">
         <h1 className="font-mono text-4xl md:text-5xl">
           404 - {t("Sivua ei löytynyt")}
         </h1>

--- a/apps/web/src/app/[locale]/signups/not-found.tsx
+++ b/apps/web/src/app/[locale]/signups/not-found.tsx
@@ -1,0 +1,48 @@
+"use client";
+import { Button, Card } from "@tietokilta/ui";
+import Link from "next/link";
+import { DinoGame } from "../../../components/dino-game";
+import {
+  I18nProviderClient,
+  useCurrentLocale,
+  useScopedI18n,
+} from "../../../locales/client";
+
+function Page() {
+  const t = useScopedI18n("not-found");
+  return (
+    <main
+      id="main"
+      className="relative mb-8 flex flex-col items-center gap-2 md:gap-6"
+    >
+      <header className="flex h-[15svh] w-full items-center justify-center bg-gray-900 p-2 text-gray-100 md:h-[25svh]">
+        <h1 className="font-mono text-4xl md:text-5xl">
+          404 - {t("Ilmoittautumista ei löytynyt")}
+        </h1>
+      </header>
+
+      <div className="relative m-auto flex max-w-prose flex-col gap-8 p-4 md:p-6">
+        <Card className="max-w-prose">
+          <p>
+            {t(
+              "Ilmoittautumista ei löytynyt tai muokkaustunniste oli väärin. Tarkista osoite tai palaa tapahtumalistaukseen.",
+            )}
+          </p>
+        </Card>
+        <Button asChild variant="link">
+          <Link href="/">{t("Tapahtumalistaukseen")}</Link>
+        </Button>
+        <DinoGame />
+      </div>
+    </main>
+  );
+}
+function PageWrapper() {
+  const locale = useCurrentLocale();
+  return (
+    <I18nProviderClient locale={locale}>
+      <Page />
+    </I18nProviderClient>
+  );
+}
+export default PageWrapper;

--- a/apps/web/src/app/[locale]/tapahtumat/not-found.tsx
+++ b/apps/web/src/app/[locale]/tapahtumat/not-found.tsx
@@ -1,0 +1,48 @@
+"use client";
+import { Button, Card } from "@tietokilta/ui";
+import Link from "next/link";
+import { DinoGame } from "../../../components/dino-game";
+import {
+  I18nProviderClient,
+  useCurrentLocale,
+  useScopedI18n,
+} from "../../../locales/client";
+
+function Page() {
+  const t = useScopedI18n("not-found");
+  return (
+    <main
+      id="main"
+      className="relative mb-8 flex flex-col items-center gap-2 md:gap-6"
+    >
+      <header className="flex h-[15svh] w-full items-center justify-center bg-gray-900 p-2 text-gray-100 md:h-[25svh]">
+        <h1 className="font-mono text-4xl md:text-5xl">
+          404 - {t("Tapahtumaa ei löytynyt")}
+        </h1>
+      </header>
+
+      <div className="relative m-auto flex max-w-prose flex-col gap-8 p-4 md:p-6">
+        <Card className="max-w-prose">
+          <p>
+            {t(
+              "Tapahtumaa ei löytynyt. Tarkista osoite tai palaa tapahtumalistaukseen.",
+            )}
+          </p>
+        </Card>
+        <Button asChild variant="link">
+          <Link href="/">{t("Tapahtumalistaukseen")}</Link>
+        </Button>
+        <DinoGame />
+      </div>
+    </main>
+  );
+}
+function PageWrapper() {
+  const locale = useCurrentLocale();
+  return (
+    <I18nProviderClient locale={locale}>
+      <Page />
+    </I18nProviderClient>
+  );
+}
+export default PageWrapper;

--- a/apps/web/src/lib/api/external/ilmomasiina/index.ts
+++ b/apps/web/src/lib/api/external/ilmomasiina/index.ts
@@ -199,6 +199,11 @@ export const getSignup = async (
         return err("ilmomasiina-signup-not-found");
       }
 
+      if (response.status === 403) {
+        // invalid edit token
+        return err("ilmomasiina-signup-not-found");
+      }
+
       return err("ilmomasiina-fetch-fail");
     }
 

--- a/apps/web/src/locales/en.ts
+++ b/apps/web/src/locales/en.ts
@@ -118,9 +118,16 @@ const en = {
   "ilmomasiina.Kopioidaan leikepöydälle": "Copying to clipboard",
   "ilmomasiina.Kopioitu leikepöydälle": "Copied to clipboard",
   "not-found.Etusivulle": "To front page",
+  "not-found.Tapahtumalistaukseen": "To event list",
   "not-found.Sivua ei löytynyt": "Page not found",
+  "not-found.Tapahtumaa ei löytynyt": "Event not found",
+  "not-found.Ilmoittautumista ei löytynyt": "Sign up not found",
   "not-found.Sivua ei löytynyt. Tarkista osoite tai palaa etusivulle.":
     "Page not found. Check the URL or return to the front page.",
+  "not-found.Tapahtumaa ei löytynyt. Tarkista osoite tai palaa tapahtumalistaukseen.":
+    "Event not found. Check the URL or return to the event list.",
+  "not-found.Ilmoittautumista ei löytynyt tai muokkaustunniste oli väärin. Tarkista osoite tai palaa tapahtumalistaukseen.":
+    "Sign up not found or the edit token was invalid. Check the URL or return to the event list.",
   "weeklyNewsletter.ayy-aalto": "AYY & Aalto",
   "weeklyNewsletter.bottom-corner": "Bottom Corner",
   "weeklyNewsletter.calendar": "Calendar",

--- a/apps/web/src/locales/fi.ts
+++ b/apps/web/src/locales/fi.ts
@@ -120,9 +120,16 @@ const fi = {
   "ilmomasiina.Kopioidaan leikepöydälle": "Kopioidaan leikepöydälle",
   "ilmomasiina.Kopioitu leikepöydälle": "Kopioitu leikepöydälle",
   "not-found.Etusivulle": "Etusivulle",
+  "not-found.Tapahtumalistaukseen": "Tapahtumalistaukseen",
   "not-found.Sivua ei löytynyt": "Sivua ei löytynyt",
+  "not-found.Tapahtumaa ei löytynyt": "Tapahtumaa ei löytynyt",
+  "not-found.Ilmoittautumista ei löytynyt": "Ilmoit­tau­tumista ei löytynyt",
   "not-found.Sivua ei löytynyt. Tarkista osoite tai palaa etusivulle.":
     "Sivua ei löytynyt. Tarkista osoite tai palaa etusivulle.",
+  "not-found.Tapahtumaa ei löytynyt. Tarkista osoite tai palaa tapahtumalistaukseen.":
+    "Tapahtumaa ei löytynyt. Tarkista osoite tai palaa tapahtumalistaukseen.",
+  "not-found.Ilmoittautumista ei löytynyt tai muokkaustunniste oli väärin. Tarkista osoite tai palaa tapahtumalistaukseen.":
+    "Ilmoittautumista ei löytynyt tai muokkaustunniste oli väärin. Tarkista osoite tai palaa tapahtumalistaukseen.",
   "weeklyNewsletter.ayy-aalto": "AYY & Aalto",
   "weeklyNewsletter.bottom-corner": "Pohjanurkkaus",
   "weeklyNewsletter.calendar": "Kalenteri",


### PR DESCRIPTION
## Description

- feat: add granular not-found pages to events and signups
- fix: add some padding to page headers

Closes #443 

### Before submitting the PR, please make sure you do the following

- [x] If your PR is related to a previously discussed issue, please [link to it](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue) here.
- [x] Prefix your PR title with feat:, fix:, chore:, or docs:.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Make sure the commit history is linear, up-to-date with main branch and does not contain any erroneous changes

### Formatting and linting

- [x] Format code with `pnpm format` and lint the project with `pnpm lint`
