### PR TITLE
feat: add confirm popover to sign up deletion

### DIFF
--- a/apps/web/src/app/[locale]/globals.css
+++ b/apps/web/src/app/[locale]/globals.css
@@ -15,6 +15,10 @@
 @tailwind components;
 
 @layer components {
+  ::backdrop {
+    @apply backdrop-blur-sm;
+  }
+
   .scroll-shadows {
     background:
     /* Shadow Cover TOP */

--- a/apps/web/src/app/[locale]/signups/[signupId]/[signupEditToken]/signup-form.tsx
+++ b/apps/web/src/app/[locale]/signups/[signupId]/[signupEditToken]/signup-form.tsx
@@ -2,7 +2,15 @@
 
 /* eslint-disable no-nested-ternary -- this is pretty cool and readable here */
 
-import { Button, Checkbox, Input, Textarea, Radio } from "@tietokilta/ui";
+import {
+  Button,
+  Checkbox,
+  Input,
+  Textarea,
+  Radio,
+  Card,
+  type ButtonProps,
+} from "@tietokilta/ui";
 // eslint-disable-next-line import/named -- Next.js magic enables this
 import { useFormState, useFormStatus } from "react-dom";
 import { useEffect } from "react";
@@ -109,14 +117,59 @@ function InputRow({
   );
 }
 
-function SubmitButton({ isConfirmed }: { isConfirmed: boolean }) {
-  const t = useScopedI18n("ilmomasiina.form");
+function StatusButton(props: Omit<ButtonProps, "disabled">) {
   const { pending } = useFormStatus();
 
+  return <Button disabled={pending} {...props} />;
+}
+
+function ConfirmDeletePopover({
+  id,
+  eventTitle,
+  deleteAction,
+}: {
+  id: string;
+  eventTitle: string;
+  deleteAction: typeof deleteSignUpAction;
+}) {
+  const t = useScopedI18n("ilmomasiina.form");
   return (
-    <Button className="w-full max-w-sm" type="submit" disabled={pending}>
-      {isConfirmed ? t("Update") : t("Submit")}
-    </Button>
+    <Card
+      id={id}
+      popover="auto"
+      className="[&:popover-open]:flex [&:popover-open]:w-full [&:popover-open]:max-w-sm [&:popover-open]:flex-col [&:popover-open]:gap-2"
+    >
+      <p>
+        {t(
+          "Are you sure you want to delete your sign up to {eventTitle}? If you delete your sign up, you will lose your place in the queue.",
+          {
+            eventTitle,
+          },
+        )}
+      </p>
+      <p>
+        <strong>{t("This action cannot be undone.")}</strong>
+      </p>
+      <Button
+        type="button"
+        popoverTarget={id}
+        popoverTargetAction="hide"
+        variant="outline"
+        className="w-full max-w-sm"
+      >
+        {t("Cancel")}
+      </Button>
+      <StatusButton
+        type="submit"
+        formNoValidate
+        // eslint-disable-next-line @typescript-eslint/no-misused-promises -- server actions can be ignored promises
+        formAction={deleteAction}
+        variant="destructive"
+        className="w-full max-w-sm"
+      >
+        {t("Delete sign up")}
+      </StatusButton>
+    </Card>
   );
 }
 
@@ -272,16 +325,22 @@ function Form({
             "You can edit your sign up or delete it later from this page, which will be sent to your email in the confirmation message",
           )}
         </p>
-        <SubmitButton isConfirmed={signup.confirmed} />
+        <StatusButton className="w-full max-w-sm" type="submit">
+          {signup.confirmed ? t("Update") : t("Submit")}
+        </StatusButton>
         <Button
-          formNoValidate
-          // eslint-disable-next-line @typescript-eslint/no-misused-promises -- server actions can be ignored promises
-          formAction={deleteAction}
+          type="button"
+          popoverTarget="confirm-delete"
           variant="outline"
           className="w-full max-w-sm"
         >
           {t("Delete sign up")}
         </Button>
+        <ConfirmDeletePopover
+          id="confirm-delete"
+          eventTitle={event.title}
+          deleteAction={deleteAction}
+        />
       </div>
     </form>
   );

--- a/apps/web/src/locales/en.ts
+++ b/apps/web/src/locales/en.ts
@@ -87,6 +87,11 @@ const en = {
   "ilmomasiina.form.Sign up saved": "Sign up saved!",
   "ilmomasiina.form.You can edit your sign up or delete it later from this page, which will be sent to your email in the confirmation message":
     "You can edit your sign up or delete it later from this page, which will be sent to your email in the confirmation message.",
+  "ilmomasiina.form.Are you sure you want to delete your sign up to {eventTitle}? If you delete your sign up, you will lose your place in the queue.":
+    "Are you sure you want to delete your sign up to {eventTitle}? If you delete your sign up, you will lose your place in the queue.",
+  "ilmomasiina.form.This action cannot be undone.":
+    "This action cannot be undone.",
+  "ilmomasiina.form.Cancel": "Cancel",
   "ilmomasiina.headers.Alkaa": "Starts",
   "ilmomasiina.headers.Ilmoittautumisaika": "Sign up time",
   "ilmomasiina.headers.Kategoria": "Category",

--- a/apps/web/src/locales/fi.ts
+++ b/apps/web/src/locales/fi.ts
@@ -87,6 +87,11 @@ const fi = {
   "ilmomasiina.form.Sign up saved": "Ilmoittautuminen tallennettu!",
   "ilmomasiina.form.You can edit your sign up or delete it later from this page, which will be sent to your email in the confirmation message":
     "Voit muokata ilmoittautumistasi tai poistaa sen myöhemmin tästä osoitteesta, joka lähetetään sähköpostiisi vahvistusviestissä.",
+  "ilmomasiina.form.Are you sure you want to delete your sign up to {eventTitle}? If you delete your sign up, you will lose your place in the queue.":
+    "Oletka varma, että haluat poistaa ilmoittautumisesi tapahtumaan {eventTitle}? Jos poistat ilmoittautumisesi, menetät paikkasi jonossa.",
+  "ilmomasiina.form.This action cannot be undone.":
+    "Tätä toimintoa ei voi perua.",
+  "ilmomasiina.form.Cancel": "Peruuta",
   "ilmomasiina.headers.Alkaa": "Alkaa",
   "ilmomasiina.headers.Ilmoittautumisaika": "Ilmoittautumisaika",
   "ilmomasiina.headers.Kategoria": "Kategoria",


### PR DESCRIPTION
## Description

- feat: add confirm popover to sign up deletion

Closes #444 

### Before submitting the PR, please make sure you do the following

- [x] If your PR is related to a previously discussed issue, please [link to it](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue) here.
- [x] Prefix your PR title with feat:, fix:, chore:, or docs:.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Make sure the commit history is linear, up-to-date with main branch and does not contain any erroneous changes

### Formatting and linting

- [x] Format code with `pnpm format` and lint the project with `pnpm lint`
