### PR TITLE
fix: mark event end time as UTC in ICS file

### DIFF
--- a/apps/web/src/lib/ics.ts
+++ b/apps/web/src/lib/ics.ts
@@ -128,7 +128,7 @@ DTEND;VALUE=DATE:${formatDate(startDate)}`;
 
   return `DTSTAMP:${formatDateTime(startDate)}Z\r
 DTSTART:${formatDateTime(startDate)}Z\r
-DTEND:${formatDateTime(endDate)}`;
+DTEND:${formatDateTime(endDate)}Z`;
 }
 
 const formatDate = (date: Date) =>


### PR DESCRIPTION
## Description

In event ICS file, end time was wrong. Fixed issue by marking also end time as UTC.

Closes #455 

### Before submitting the PR, please make sure you do the following

- [x] If your PR is related to a previously discussed issue, please [link to it](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue) here.
- [x] Prefix your PR title with feat:, fix:, chore:, or docs:.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Make sure the commit history is linear, up-to-date with main branch and does not contain any erroneous changes

### Formatting and linting

- [ ] Format code with `pnpm format` and lint the project with `pnpm lint`
