### PR TITLE
fix: Prevent accidental language changes caused by prefetching

### DIFF
--- a/apps/web/src/components/main-nav/language-selector.tsx
+++ b/apps/web/src/components/main-nav/language-selector.tsx
@@ -16,6 +16,7 @@ export function LanguageSelector() {
           <NextLink
             className="underline-offset-2 hover:text-gray-400 hover:underline aria-[current=page]:font-bold aria-[current=page]:underline"
             href={pathname.replace(/^\/(?:en|fi)/, "/fi")}
+            prefetch={false}
           >
             <span aria-hidden="true">FI</span>
             <span className="sr-only">Suomeksi</span>
@@ -27,6 +28,7 @@ export function LanguageSelector() {
           <NextLink
             className="underline-offset-2 hover:text-gray-400 hover:underline aria-[current=page]:font-bold aria-[current=page]:underline"
             href={pathname.replace(/^\/(?:en|fi)/, "/en")}
+            prefetch={false}
           >
             <span aria-hidden="true">EN</span>
             <span className="sr-only">In English</span>

--- a/apps/web/src/components/mobile-nav/language-selector.tsx
+++ b/apps/web/src/components/mobile-nav/language-selector.tsx
@@ -16,6 +16,7 @@ export function LanguageSelector() {
           aria-current={isFinnish ? "page" : undefined}
           className="underline-offset-2 hover:underline aria-[current=page]:font-bold aria-[current=page]:underline"
           href={pathname.replace(/^\/(?:en|fi)/, "/fi")}
+          prefetch={false}
         >
           <span aria-hidden="true">FI</span>
           <span className="sr-only">Suomeksi</span>
@@ -26,6 +27,7 @@ export function LanguageSelector() {
           aria-current={isEnglish ? "page" : undefined}
           className="underline-offset-2 hover:underline aria-[current=page]:font-bold aria-[current=page]:underline"
           href={pathname.replace(/^\/(?:en|fi)/, "/en")}
+          prefetch={false}
         >
           <span aria-hidden="true">EN</span>
           <span className="sr-only">In English</span>


### PR DESCRIPTION
## Description

Prefetching language selector links causes the language cookie to change (which in turn causes the locale-less url `tietokilta.fi` to open always on different language), so disabled prefetching for them. 

Closes #486

### Before submitting the PR, please make sure you do the following

- [x] If your PR is related to a previously discussed issue, please [link to it](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue) here.
- [x] Prefix your PR title with feat:, fix:, chore:, or docs:.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Make sure the commit history is linear, up-to-date with main branch and does not contain any erroneous changes

### Formatting and linting

- [x] Format code with `pnpm format` and lint the project with `pnpm lint`
