### PR TITLE
fix:Make invoice success text larger

### DIFF
--- a/apps/web/src/components/invoice-generator/index.tsx
+++ b/apps/web/src/components/invoice-generator/index.tsx
@@ -115,7 +115,7 @@ function SubmitButton({
       {formState?.success ? (
         <p
           data-form-status
-          className="w-full max-w-sm text-green-600"
+          className="text-2l w-full max-w-sm text-green-600"
           aria-live="polite"
         >
           {t("Sent invoice")}


### PR DESCRIPTION
The text has been made bigger so it's easier to read. Now the size is 2xl.

## Description
[Fixes #482 ](https://github.com/Tietokilta/web/issues/482)

### Before submitting the PR, please make sure you do the following

- [ X] If your PR is related to a previously discussed issue, please [link to it](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue) here.
- [ X] Prefix your PR title with feat:, fix:, chore:, or docs:.
- [X ] This message body should clearly illustrate what problems it solves.
- [ X] Make sure the commit history is linear, up-to-date with main branch and does not contain any erroneous changes

### Formatting and linting

- [ X] Format code with `pnpm format` and lint the project with `pnpm lint`
