### PR TITLE
Fix: Newsletter numbering

### DIFF
--- a/apps/cms/src/collections/weekly-newsletters/newsletter-button.tsx
+++ b/apps/cms/src/collections/weekly-newsletters/newsletter-button.tsx
@@ -6,14 +6,6 @@ const getIdFromUrl = (): string => {
   const id = pathArray[pathArray.length - 1];
   return id;
 };
-const getEmail = async (): Promise<{
-  html: string;
-  subject: string;
-}> => {
-  const newsletterId = getIdFromUrl();
-  const response = await fetch(`/api/weekly-newsletters/mail/${newsletterId}`);
-  return (await response.json()) as { html: string; subject: string };
-};
 
 const getTelegramMessage = async (
   locale: string,
@@ -39,13 +31,11 @@ const NewsletterButton = (): React.ReactElement => {
       `Are you sure you want to send email? Remember to publish changes before.`,
     );
     if (!confirmed) return;
-    const email = await getEmail();
-    await fetch("/api/weekly-newsletters/mail", {
+    await fetch(`/api/weekly-newsletters/mail/${newsletterId}`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
       },
-      body: JSON.stringify(email),
     });
   };
   const buttonStyle = {

--- a/apps/cms/src/collections/weekly-newsletters/weekly-newsletters.ts
+++ b/apps/cms/src/collections/weekly-newsletters/weekly-newsletters.ts
@@ -92,7 +92,7 @@ export const WeeklyNewsletters: CollectionConfig = {
   },
   endpoints: [
     {
-      path: "/mail",
+      path: "/mail/:newsletterId",
       method: "post",
       handler: newsletterSenderController as PayloadHandler,
     },

--- a/apps/cms/src/emails/helper-components.tsx
+++ b/apps/cms/src/emails/helper-components.tsx
@@ -215,13 +215,17 @@ function NewsItemContent({
 function NewsSection({
   newsItem,
   locale,
+  order,
 }: {
   newsItem: NewsItem;
   locale: "en" | "fi";
+  order: string;
 }): JSX.Element {
   return (
     <article>
-      <h3 id={stringToId(newsItem.title)}>{newsItem.title}</h3>
+      <h3 id={stringToId(newsItem.title)}>
+        {order} {newsItem.title}
+      </h3>
       <NewsItemContent item={newsItem} locale={locale} />
     </article>
   );
@@ -231,18 +235,27 @@ export function NewsletterCategory({
   title,
   newsItems,
   locale,
+  order,
 }: {
   title: string;
   newsItems: NewsItem[];
   locale: "en" | "fi";
+  order: string;
 }): JSX.Element | null {
   if (newsItems.length === 0) return null;
 
   return (
     <div>
-      <h2 id={stringToId(title)}>{title}</h2>
-      {newsItems.map((newsItem) => (
-        <NewsSection key={newsItem.id} newsItem={newsItem} locale={locale} />
+      <h2 id={stringToId(title)}>
+        {order} {title}
+      </h2>
+      {newsItems.map((newsItem, i) => (
+        <NewsSection
+          key={newsItem.id}
+          newsItem={newsItem}
+          locale={locale}
+          order={order + (i + 1).toString()}
+        />
       ))}
     </div>
   );
@@ -253,11 +266,13 @@ export function Calendar({
   eventsNextWeek,
   signupsThisWeek,
   locale,
+  order,
 }: {
   eventsThisWeek: NewsItem[];
   eventsNextWeek: NewsItem[];
   signupsThisWeek: NewsItem[];
   locale: "en" | "fi";
+  order: string;
 }): JSX.Element | null {
   if (
     eventsThisWeek.length === 0 &&
@@ -282,7 +297,9 @@ export function Calendar({
   };
   return (
     <div>
-      <h2 id={stringToId(t[locale].calendar)}>{t[locale].calendar}</h2>
+      <h2 id={stringToId(t[locale].calendar)}>
+        {order} {t[locale].calendar}
+      </h2>
       {eventsThisWeek.length > 0 ? (
         <div>
           <span>{t[locale]["this-week"]}:</span>

--- a/apps/cms/src/emails/newsletter-email.tsx
+++ b/apps/cms/src/emails/newsletter-email.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { type WeeklyNewsletter } from "@tietokilta/cms-types/payload";
-import { Html } from "@react-email/components";
+import { Head, Html, Font } from "@react-email/components";
 import { newsletterPreviewProps } from "./newsletter-example";
 import { Newsletter } from "./newsletter";
 
@@ -19,6 +19,16 @@ export const NewsletterEmail = ({
 }: NewsletterEmailProps): React.ReactElement => {
   return (
     <Html>
+      <Head>
+        <Font
+          fontFamily="Inter"
+          fallbackFontFamily="sans-serif"
+          webFont={{
+            url: "https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap",
+            format: "woff2",
+          }}
+        />
+      </Head>
       <Newsletter
         newsletter={finnishNewsletter}
         locale="fi"

--- a/apps/cms/src/emails/newsletter.tsx
+++ b/apps/cms/src/emails/newsletter.tsx
@@ -80,12 +80,12 @@ export const Newsletter = ({
     (newsItem) =>
       newsItem.signupStartDate && isThisWeek(newsItem.signupStartDate),
   );
-  const toc: TocItem[] = [
+  const showCalendar =
     eventsThisWeek.length > 0 ||
     eventsNextWeek.length > 0 ||
-    signupsThisWeek.length > 0
-      ? { text: t[locale].calendar, children: [] }
-      : null,
+    signupsThisWeek.length > 0;
+  const toc: TocItem[] = [
+    showCalendar ? { text: t[locale].calendar, children: [] } : null,
     guildNewsItems.length > 0
       ? {
           text: t[locale].guild,
@@ -119,6 +119,12 @@ export const Newsletter = ({
         }
       : null,
   ].filter((itemOrNull): itemOrNull is TocItem => Boolean(itemOrNull));
+  const newsletterCategories = [
+    { title: t[locale].guild, newsItems: guildNewsItems },
+    { title: t[locale]["ayy-aalto"], newsItems: ayyAaltoNewsItems },
+    { title: t[locale].other, newsItems: otherNewsItems },
+    { title: t[locale]["bottom-corner"], newsItems: bottomCornerNewsItems },
+  ];
   return (
     <div>
       <div>
@@ -133,27 +139,22 @@ export const Newsletter = ({
           eventsNextWeek={eventsNextWeek}
           signupsThisWeek={signupsThisWeek}
           locale={locale}
+          order={"1."}
         />
-        <NewsletterCategory
-          title={t[locale].guild}
-          newsItems={guildNewsItems}
-          locale={locale}
-        />
-        <NewsletterCategory
-          title={t[locale]["ayy-aalto"]}
-          newsItems={ayyAaltoNewsItems}
-          locale={locale}
-        />
-        <NewsletterCategory
-          title={t[locale].other}
-          newsItems={otherNewsItems}
-          locale={locale}
-        />
-        <NewsletterCategory
-          title={t[locale]["bottom-corner"]}
-          newsItems={bottomCornerNewsItems}
-          locale={locale}
-        />
+        {newsletterCategories
+          .filter((c) => c.newsItems.length > 0)
+          .map((category, index) => (
+            <NewsletterCategory
+              title={category.title}
+              newsItems={category.newsItems}
+              locale={locale}
+              order={
+                showCalendar
+                  ? `${(index + 2).toString()}.`
+                  : `${(index + 1).toString()}.`
+              }
+            />
+          ))}
       </div>
 
       <p>


### PR DESCRIPTION
## Description
Few improvements to newsletter email. Adds numbering to newsletter category headers and includes fonts for those email providers that supports it. Here should be the list of supported email providers. https://www.caniemail.com/features/css-at-font-face/
- ...

### Before submitting the PR, please make sure you do the following

- [ ] If your PR is related to a previously discussed issue, please [link to it](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue) here.
- [X] Prefix your PR title with feat:, fix:, chore:, or docs:.
- [X] This message body should clearly illustrate what problems it solves.
- [X] Make sure the commit history is linear, up-to-date with main branch and does not contain any erroneous changes

### Formatting and linting

- [X] Format code with `pnpm format` and lint the project with `pnpm lint`
