### PR TITLE
fix: disable sign up editing and deletion if event sign ups are closed

### DIFF
--- a/apps/web/src/app/[locale]/signups/[signupId]/[signupEditToken]/signup-form.tsx
+++ b/apps/web/src/app/[locale]/signups/[signupId]/[signupEditToken]/signup-form.tsx
@@ -140,10 +140,11 @@ function InputRow({
   );
 }
 
-function StatusButton(props: Omit<ButtonProps, "disabled">) {
+function StatusButton({ disabled, ...props }: ButtonProps) {
   const { pending } = useFormStatus();
 
-  return <Button disabled={pending} {...props} />;
+  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- it's on purpose to overwrite false in case it's pending
+  return <Button disabled={disabled || pending} {...props} />;
 }
 
 function ConfirmDeletePopover({
@@ -215,6 +216,9 @@ function Form({
 }) {
   const t = useScopedI18n("ilmomasiina.form");
   const [state, formAction] = useFormState(saveAction, null);
+  const isSignupPeriodEnded =
+    !!event.registrationEndDate &&
+    new Date(event.registrationEndDate) < new Date();
 
   useEffect(() => {
     const errorFields = state?.errors
@@ -345,16 +349,30 @@ function Form({
             errors={state?.errors?.[question.id]}
           />
         ))}
-        <p className="w-full max-w-sm">
-          {t(
-            "You can edit your sign up or delete it later from this page, which will be sent to your email in the confirmation message",
+        <p
+          className={cn(
+            "w-full max-w-sm",
+            isSignupPeriodEnded && "text-red-600",
           )}
+        >
+          {isSignupPeriodEnded
+            ? t(
+                "Your signup cannot be changed anymore as the signup for the event has closed",
+              )
+            : t(
+                "You can edit your sign up or delete it later from this page, which will be sent to your email in the confirmation message",
+              )}
         </p>
-        <StatusButton className="w-full max-w-sm" type="submit">
+        <StatusButton
+          disabled={isSignupPeriodEnded}
+          className="w-full max-w-sm"
+          type="submit"
+        >
           {signup.confirmed ? t("Update") : t("Submit")}
         </StatusButton>
         <input
           type="button"
+          disabled={isSignupPeriodEnded}
           // @ts-expect-error -- this is a valid attribute
           popovertarget="confirm-delete"
           className={cn(

--- a/apps/web/src/locales/en.ts
+++ b/apps/web/src/locales/en.ts
@@ -101,6 +101,8 @@ const en = {
     "Are you sure you want to delete your sign up to {eventTitle}? If you delete your sign up, you will lose your place in the queue.",
   "ilmomasiina.form.This action cannot be undone.":
     "This action cannot be undone.",
+  "ilmomasiina.form.Your signup cannot be changed anymore as the signup for the event has closed":
+    "Your signup cannot be changed anymore as the signup for the event has closed.",
   "ilmomasiina.form.Cancel": "Cancel",
   "ilmomasiina.headers.Alkaa": "Starts",
   "ilmomasiina.headers.Ilmoittautumisaika": "Sign up time",

--- a/apps/web/src/locales/fi.ts
+++ b/apps/web/src/locales/fi.ts
@@ -97,6 +97,8 @@ const fi = {
   "ilmomasiina.form.Sign up saved": "Ilmoittautuminen tallennettu!",
   "ilmomasiina.form.You can edit your sign up or delete it later from this page, which will be sent to your email in the confirmation message":
     "Voit muokata ilmoittautumistasi tai poistaa sen myöhemmin tästä osoitteesta, joka lähetetään sähköpostiisi vahvistusviestissä.",
+  "ilmomasiina.form.Your signup cannot be changed anymore as the signup for the event has closed":
+    "Ilmoittautumistasi ei voi enää muokata tai perua, koska tapahtuman ilmoittautuminen on sulkeutunut.",
   "ilmomasiina.form.Are you sure you want to delete your sign up to {eventTitle}? If you delete your sign up, you will lose your place in the queue.":
     "Oletka varma, että haluat poistaa ilmoittautumisesi tapahtumaan {eventTitle}? Jos poistat ilmoittautumisesi, menetät paikkasi jonossa.",
   "ilmomasiina.form.This action cannot be undone.":


### PR DESCRIPTION
## Description

- fix: disable sign up editing and deletion if event sign ups are closed

### Before submitting the PR, please make sure you do the following

- [ ] If your PR is related to a previously discussed issue, please [link to it](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue) here.
- [x] Prefix your PR title with feat:, fix:, chore:, or docs:.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Make sure the commit history is linear, up-to-date with main branch and does not contain any erroneous changes

### Formatting and linting

- [x] Format code with `pnpm format` and lint the project with `pnpm lint`
