### PR TITLE
feat: Scroll to top when opening signup page

### DIFF
--- a/apps/web/src/app/[locale]/signups/[signupId]/[signupEditToken]/signup-form.tsx
+++ b/apps/web/src/app/[locale]/signups/[signupId]/[signupEditToken]/signup-form.tsx
@@ -218,6 +218,11 @@ function Form({
     !!event.registrationEndDate &&
     new Date(event.registrationEndDate) < new Date();
 
+  // On first render, scroll to top
+  useEffect(() => {
+    window.scrollTo({ top: 0, behavior: "instant" });
+  }, []);
+
   useEffect(() => {
     const errorFields = state?.errors
       ? Object.keys(state.errors).filter((v) => v !== "_form")


### PR DESCRIPTION
## Description

When clicking "Sign up" on event page, the scroll position didn't change (problem with phones, since the signup page was then scrolled to footer). Now the Sign up form always scrolls the page to top when rendered for the first time.

Handles the same issue as #458 so if this gets merged, that should probably be closed.

Closes #457.

### Before submitting the PR, please make sure you do the following

- [x] If your PR is related to a previously discussed issue, please [link to it](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue) here.
- [x] Prefix your PR title with feat:, fix:, chore:, or docs:.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Make sure the commit history is linear, up-to-date with main branch and does not contain any erroneous changes

### Formatting and linting

- [x] Format code with `pnpm format` and lint the project with `pnpm lint`
