### PR TITLE
fix: force ics cache busting by setting dtstamp as current time

### DIFF
--- a/apps/web/src/lib/ics.ts
+++ b/apps/web/src/lib/ics.ts
@@ -119,17 +119,18 @@ END:VEVENT`;
 }
 
 function formatDates(start: string, end?: string | null) {
+  const nowDate = new Date();
   const startDate = new Date(start);
   if (!end) {
     // Make the event an all-day event if there's no end date.
-    return `DTSTAMP:${formatDateTime(startDate)}Z\r
+    return `DTSTAMP:${formatDateTime(nowDate)}Z\r
 DTSTART;VALUE=DATE:${formatDate(startDate)}\r
 DTEND;VALUE=DATE:${formatDate(startDate)}`;
   }
 
   const endDate = new Date(end);
 
-  return `DTSTAMP:${formatDateTime(startDate)}Z\r
+  return `DTSTAMP:${formatDateTime(nowDate)}Z\r
 DTSTART:${formatDateTime(startDate)}Z\r
 DTEND:${formatDateTime(endDate)}Z`;
 }


### PR DESCRIPTION
## Description

- fix: force ics cache busting by setting dtstamp as current time

### Before submitting the PR, please make sure you do the following

- [x] If your PR is related to a previously discussed issue, please [link to it](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue) here.
- [x] Prefix your PR title with feat:, fix:, chore:, or docs:.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Make sure the commit history is linear, up-to-date with main branch and does not contain any erroneous changes

### Formatting and linting

- [x] Format code with `pnpm format` and lint the project with `pnpm lint`
