### PR TITLE
feat: support markdown localization in ilmomasiina UI

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -36,6 +36,7 @@
     "tailwind-merge": "catalog:",
     "tailwindcss": "catalog:",
     "tailwindcss-animate": "catalog:",
+    "unist-util-visit": "^5.0.0",
     "use-scramble": "^2.2.15",
     "zod": "^3.23.8"
   },
@@ -46,6 +47,7 @@
     "@tietokilta/config-typescript": "workspace:*",
     "@tietokilta/eslint-config": "workspace:*",
     "@types/lodash": "^4.17.13",
+    "@types/mdast": "^4.0.4",
     "@types/node": "catalog:",
     "@types/qs": "^6.9.16",
     "@types/react": "catalog:",
@@ -54,6 +56,7 @@
     "eslint": "catalog:",
     "react-dvd-screensaver": "^0.1.1",
     "typescript": "catalog:",
-    "typescript-eslint": "catalog:"
+    "typescript-eslint": "catalog:",
+    "unified": "^11.0.5"
   }
 }

--- a/apps/web/src/app/[locale]/events/[slug]/page.tsx
+++ b/apps/web/src/app/[locale]/events/[slug]/page.tsx
@@ -28,6 +28,7 @@ import { BackButton } from "../../../../components/back-button";
 import { getCurrentLocale, getScopedI18n } from "../../../../locales/server";
 import { DateTime } from "../../../../components/datetime";
 import { openGraphImage } from "../../../shared-metadata";
+import { remarkI18n } from "../../../../lib/plugins/remark-i18n";
 import { SignUpButton } from "./signup-button";
 
 async function SignUpText({
@@ -432,6 +433,7 @@ export const generateMetadata = async ({
 };
 
 export default async function Page({ params: { slug } }: PageProps) {
+  const locale = await getCurrentLocale();
   const event = await fetchEvent(slug);
   const t = await getScopedI18n("action");
   if (!event.ok && event.error === "ilmomasiina-event-not-found") {
@@ -458,7 +460,9 @@ export default async function Page({ params: { slug } }: PageProps) {
                 <Tldr event={event.data} />
                 {event.data.description ? (
                   <div className="prose">
-                    <Markdown remarkPlugins={[remarkGfm]}>
+                    <Markdown
+                      remarkPlugins={[[remarkI18n, { locale }], remarkGfm]}
+                    >
                       {event.data.description}
                     </Markdown>
                   </div>

--- a/apps/web/src/app/[locale]/signups/[signupId]/[signupEditToken]/page.tsx
+++ b/apps/web/src/app/[locale]/signups/[signupId]/[signupEditToken]/page.tsx
@@ -6,7 +6,8 @@ import {
   deleteSignUpAction,
   saveSignUpAction,
 } from "../../../../../lib/api/external/ilmomasiina/actions";
-import { getScopedI18n } from "../../../../../locales/server";
+import { getCurrentLocale, getScopedI18n } from "../../../../../locales/server";
+import { getLocalizedEventTitle } from "../../../../../lib/utils";
 import { SignupForm } from "./signup-form";
 
 interface PageProps {
@@ -48,6 +49,7 @@ export default async function Page({
     throw new Error("Failed to fetch signup info");
   }
 
+  const locale = await getCurrentLocale();
   const t = await getScopedI18n("ilmomasiina.form");
 
   return (
@@ -58,7 +60,8 @@ export default async function Page({
       <div className="relative flex max-w-4xl flex-col items-center gap-8 p-4 md:p-6">
         <hgroup className="space-y-4 text-pretty">
           <h1 className="font-mono text-2xl md:text-4xl">
-            {t("Edit sign up")} - {signupInfo.data.event.title}
+            {t("Edit sign up")} -{" "}
+            {getLocalizedEventTitle(signupInfo.data.event.title, locale)}
           </h1>
           <p>
             {signupInfo.data.signup.status === "in-queue"

--- a/apps/web/src/app/[locale]/signups/[signupId]/[signupEditToken]/signup-form.tsx
+++ b/apps/web/src/app/[locale]/signups/[signupId]/[signupEditToken]/signup-form.tsx
@@ -29,7 +29,7 @@ import {
   useCurrentLocale,
   useScopedI18n,
 } from "../../../../../locales/client";
-import { cn } from "../../../../../lib/utils";
+import { cn, getLocalizedEventTitle } from "../../../../../lib/utils";
 
 type FieldErrorI18n = ReturnType<typeof useScopedI18n>;
 
@@ -212,6 +212,7 @@ function Form({
   saveAction: typeof saveSignUpAction;
   deleteAction: typeof deleteSignUpAction;
 }) {
+  const locale = useCurrentLocale();
   const t = useScopedI18n("ilmomasiina.form");
   const [state, formAction] = useFormState(saveAction, null);
   const isSignupPeriodEnded =
@@ -386,7 +387,7 @@ function Form({
         />
         <ConfirmDeletePopover
           id="confirm-delete"
-          eventTitle={event.title}
+          eventTitle={getLocalizedEventTitle(event.title, locale)}
           deleteAction={deleteAction}
         />
       </div>

--- a/apps/web/src/components/events-display/index.tsx
+++ b/apps/web/src/components/events-display/index.tsx
@@ -14,7 +14,11 @@ import {
 import type { IlmomasiinaEvent } from "../../lib/api/external/ilmomasiina";
 import { fetchUpcomingEvents } from "../../lib/api/external/ilmomasiina";
 import { getCurrentLocale, getI18n } from "../../locales/server";
-import { formatDateTime, formatDateTimeOptions } from "../../lib/utils";
+import {
+  formatDateTime,
+  formatDateTimeOptions,
+  getLocalizedEventTitle,
+} from "../../lib/utils";
 import { DateTime } from "../datetime";
 
 function EventListSkeleton() {
@@ -37,14 +41,14 @@ async function EventItem({ event }: { event: IlmomasiinaEvent }) {
     <li className="shadow-solid flex flex-col justify-between gap-4 rounded-md border-2 border-gray-900 p-4 font-mono text-gray-900 md:flex-row md:items-center">
       <div className="flex-1 shrink-0">
         <span className="block text-pretty text-lg font-bold">
-          {event.title}
+          {getLocalizedEventTitle(event.title, locale)}
         </span>
         <Button asChild className="hidden md:inline-flex" variant="link">
           <Link href={eventUrl}>
             <span aria-hidden="true">{t("action.Read more")}</span>
             <span className="sr-only">
               {t("action.Read more about {something}", {
-                something: event.title,
+                something: getLocalizedEventTitle(event.title, locale),
               })}
             </span>
           </Link>
@@ -81,7 +85,7 @@ async function EventItem({ event }: { event: IlmomasiinaEvent }) {
           <span aria-hidden="true">{t("action.Read more")}</span>
           <span className="sr-only">
             {t("action.Read more about {something}", {
-              something: event.title,
+              something: getLocalizedEventTitle(event.title, locale),
             })}
           </span>
         </Link>

--- a/apps/web/src/custom-pages/event-calendar.tsx
+++ b/apps/web/src/custom-pages/event-calendar.tsx
@@ -20,15 +20,17 @@ import {
   useCurrentLocale,
   I18nProviderClient,
 } from "../locales/client";
+import { getLocalizedEventTitle } from "../lib/utils";
+import type { Locale } from "../locales/server";
 
 type IlmomasiinEventWithDate = IlmomasiinaEvent & { date: string };
 type CalendarEvent = Omit<Event, "resource"> & { resource: { url: string } };
 
 // Make calendar events into clickable links.
-function EventElement(event: EventProps<CalendarEvent>) {
+function EventElement(props: EventProps<CalendarEvent>) {
   return (
-    <Link className="block h-full" href={event.event.resource.url}>
-      {event.title}
+    <Link className="block h-full" href={props.event.resource.url}>
+      {props.title}
     </Link>
   );
 }
@@ -40,7 +42,7 @@ function EventCalendar({
 }: {
   events: IlmomasiinaEvent[];
   eventsUrl: string;
-  locale: string;
+  locale: Locale;
 }) {
   const t = useScopedI18n("calendar");
   const ta = useScopedI18n("action");
@@ -63,7 +65,7 @@ function EventCalendar({
     return {
       start: startDate,
       end: endDate,
-      title: event.title,
+      title: getLocalizedEventTitle(event.title, locale),
       resource: {
         url: eventUrl,
       },

--- a/apps/web/src/custom-pages/events-page.tsx
+++ b/apps/web/src/custom-pages/events-page.tsx
@@ -12,6 +12,7 @@ import {
   formatDateYear,
   formatDateYearOptions,
   formatDatetimeYear,
+  getLocalizedEventTitle,
 } from "../lib/utils";
 import { BackButton } from "../components/back-button";
 import { getCurrentLocale, getScopedI18n } from "../locales/server";
@@ -130,7 +131,7 @@ async function EventCard({ event }: { event: IlmomasiinaEvent }) {
         href={`/${locale}/${t("events")}/${event.slug}`}
         className="text-pretty text-lg font-bold underline-offset-2 before:absolute before:left-0 before:top-0 before:z-0 before:block before:size-full before:cursor-[inherit] group-hover:underline md:w-1/3"
       >
-        <h2>{event.title}</h2>
+        <h2>{getLocalizedEventTitle(event.title, locale)}</h2>
       </Link>
 
       {event.date ? (

--- a/apps/web/src/lib/plugins/remark-i18n.ts
+++ b/apps/web/src/lib/plugins/remark-i18n.ts
@@ -1,0 +1,107 @@
+import type { Plugin } from "unified";
+import type { Root, Definition, Parent } from "mdast";
+import { visit } from "unist-util-visit";
+
+interface Options {
+  locale?: string;
+}
+
+/**
+ * Split markdown content into multiple trees based on language definitions.
+ *
+ * Example:
+ * ```markdown
+ * Default language content
+ *
+ * [lang]: # (en)
+ * English content
+ * ```
+ *
+ * Will be transformed depending on the locale option to either:
+ * ```markdown
+ * Default language content
+ * ```
+ *
+ * or:
+ *
+ * ```markdown
+ * English content
+ * ```
+ */
+export const remarkI18n: Plugin<[options: Options] | undefined[], Root> =
+  function (options = {}, ..._ignored) {
+    const defaultLocaleTree: Root = { type: "root", children: [] };
+    const localeTrees = new Map<string, Root>();
+
+    return (tree: Root) => {
+      let currentLocale: string | null = null;
+      let lastDefinitionIndex = -1;
+
+      // Find all language definitions and split content
+      visit(
+        tree,
+        "definition",
+        (node: Definition, index?: number, parent?: Parent) => {
+          const isLangDefinition =
+            node.label === "lang" &&
+            node.identifier === "lang" &&
+            node.url === "#";
+          if (!isLangDefinition || !node.title) {
+            return;
+          }
+
+          const locale = node.title;
+          if (!localeTrees.has(locale)) {
+            localeTrees.set(locale, { type: "root", children: [] });
+          }
+
+          // Move nodes between last definition and this one to appropriate tree
+          const targetTree = currentLocale
+            ? // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- checked above
+              localeTrees.get(currentLocale)!
+            : defaultLocaleTree;
+
+          const nodesToMove =
+            parent?.children.slice(lastDefinitionIndex + 1, index) ?? [];
+          targetTree.children.push(...nodesToMove);
+
+          currentLocale = locale;
+          lastDefinitionIndex = index ?? -1;
+        },
+      );
+
+      // Handle remaining nodes after the last definition
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- extra safety just in case
+      if (tree.type === "root") {
+        const remainingNodes = tree.children.slice(lastDefinitionIndex + 1);
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- false negative
+        const targetTree = currentLocale
+          ? // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- we know it's there because of the last definition
+            localeTrees.get(currentLocale)!
+          : defaultLocaleTree;
+        targetTree.children.push(...remainingNodes);
+      }
+
+      const cleanTree = (_tree: Root) => {
+        _tree.children = _tree.children.filter(
+          (node) =>
+            !(
+              node.type === "definition" &&
+              node.label === "lang" &&
+              node.url === "#"
+            ),
+        );
+      };
+
+      cleanTree(defaultLocaleTree);
+      localeTrees.forEach(cleanTree);
+
+      // Return the appropriate tree based on options
+      if (options.locale && localeTrees.has(options.locale)) {
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- checked above
+        return localeTrees.get(options.locale)!;
+      }
+
+      return defaultLocaleTree;
+    };
+  };

--- a/apps/web/src/lib/utils.ts
+++ b/apps/web/src/lib/utils.ts
@@ -294,6 +294,17 @@ export const getQuotasWithOpenAndQueue = (
   return quotasWithOpenAndQueue;
 };
 
+export function getLocalizedEventTitle(eventTitle: string, locale: Locale) {
+  const titleLocaleSeparator = " // ";
+  const [fiTitle, enTitle] = eventTitle.split(titleLocaleSeparator);
+
+  if (locale === "en") {
+    return enTitle || fiTitle;
+  }
+
+  return fiTitle;
+}
+
 /**
  * Typescript gymnastics
  */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -259,6 +259,9 @@ importers:
       tailwindcss-animate:
         specifier: 'catalog:'
         version: 1.0.7(tailwindcss@3.4.14)
+      unist-util-visit:
+        specifier: ^5.0.0
+        version: 5.0.0
       use-scramble:
         specifier: ^2.2.15
         version: 2.2.15(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -284,6 +287,9 @@ importers:
       '@types/lodash':
         specifier: ^4.17.13
         version: 4.17.13
+      '@types/mdast':
+        specifier: ^4.0.4
+        version: 4.0.4
       '@types/node':
         specifier: 'catalog:'
         version: 22.8.4
@@ -311,6 +317,9 @@ importers:
       typescript-eslint:
         specifier: 'catalog:'
         version: 8.12.2(eslint@9.13.0(jiti@1.21.6))(typescript@5.6.3)
+      unified:
+        specifier: ^11.0.5
+        version: 11.0.5
 
   packages/cms-types: {}
 
@@ -5767,8 +5776,8 @@ packages:
   mdast-util-find-and-replace@3.0.1:
     resolution: {integrity: sha512-SG21kZHGC3XRTSUhtofZkBzZTJNM5ecCi0SK2IMKmSXR8vO3peL+kb1O0z7Zl83jKtutG4k5Wv/W7V3/YHvzPA==}
 
-  mdast-util-from-markdown@2.0.1:
-    resolution: {integrity: sha512-aJEUyzZ6TzlsX2s5B4Of7lN7EQtAxvtradMMglCQDyaTFgse6CmtmdJ15ElnVRlCg1vpNyVtbem0PWzlNieZsA==}
+  mdast-util-from-markdown@2.0.2:
+    resolution: {integrity: sha512-uZhTV/8NBuw0WHkPTrCqDOl0zVe1BIng5ZtHoDk49ME1qqcjYmmLmOf0gELgcRMxN4w2iuIeVso5/6QymSrgmA==}
 
   mdast-util-gfm-autolink-literal@2.0.1:
     resolution: {integrity: sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==}
@@ -14453,7 +14462,7 @@ snapshots:
       unist-util-is: 6.0.0
       unist-util-visit-parents: 6.0.1
 
-  mdast-util-from-markdown@2.0.1:
+  mdast-util-from-markdown@2.0.2:
     dependencies:
       '@types/mdast': 4.0.4
       '@types/unist': 3.0.3
@@ -14482,7 +14491,7 @@ snapshots:
     dependencies:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.1
+      mdast-util-from-markdown: 2.0.2
       mdast-util-to-markdown: 2.1.0
       micromark-util-normalize-identifier: 2.0.0
     transitivePeerDependencies:
@@ -14491,7 +14500,7 @@ snapshots:
   mdast-util-gfm-strikethrough@2.0.0:
     dependencies:
       '@types/mdast': 4.0.4
-      mdast-util-from-markdown: 2.0.1
+      mdast-util-from-markdown: 2.0.2
       mdast-util-to-markdown: 2.1.0
     transitivePeerDependencies:
       - supports-color
@@ -14501,7 +14510,7 @@ snapshots:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
       markdown-table: 3.0.3
-      mdast-util-from-markdown: 2.0.1
+      mdast-util-from-markdown: 2.0.2
       mdast-util-to-markdown: 2.1.0
     transitivePeerDependencies:
       - supports-color
@@ -14510,14 +14519,14 @@ snapshots:
     dependencies:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.1
+      mdast-util-from-markdown: 2.0.2
       mdast-util-to-markdown: 2.1.0
     transitivePeerDependencies:
       - supports-color
 
   mdast-util-gfm@3.0.0:
     dependencies:
-      mdast-util-from-markdown: 2.0.1
+      mdast-util-from-markdown: 2.0.2
       mdast-util-gfm-autolink-literal: 2.0.1
       mdast-util-gfm-footnote: 2.0.0
       mdast-util-gfm-strikethrough: 2.0.0
@@ -14533,7 +14542,7 @@ snapshots:
       '@types/hast': 3.0.4
       '@types/mdast': 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.1
+      mdast-util-from-markdown: 2.0.2
       mdast-util-to-markdown: 2.1.0
     transitivePeerDependencies:
       - supports-color
@@ -14546,7 +14555,7 @@ snapshots:
       '@types/unist': 3.0.3
       ccount: 2.0.1
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.1
+      mdast-util-from-markdown: 2.0.2
       mdast-util-to-markdown: 2.1.0
       parse-entities: 4.0.1
       stringify-entities: 4.0.4
@@ -14561,7 +14570,7 @@ snapshots:
       '@types/hast': 3.0.4
       '@types/mdast': 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.1
+      mdast-util-from-markdown: 2.0.2
       mdast-util-to-markdown: 2.1.0
     transitivePeerDependencies:
       - supports-color
@@ -16329,7 +16338,7 @@ snapshots:
   remark-parse@11.0.0:
     dependencies:
       '@types/mdast': 4.0.4
-      mdast-util-from-markdown: 2.0.1
+      mdast-util-from-markdown: 2.0.2
       micromark-util-types: 2.0.0
       unified: 11.0.5
     transitivePeerDependencies:


### PR DESCRIPTION
## Description

- feat: implement support for localizing event titles in UI with common practice divider
- feat: implement support for custom localization in markdown content

  This is done with a custom markdown `Definition` block.
  
  Example:
  ```markdown
  Default language content
  
  [lang]: # (en)
  
  English content
  ```
  
  Will be transformed depending on the locale option to either:
  ```markdown
  Default language content
  ```
  
  or:
  ```markdown
  English content
  ```
  
  Without the custom plugin, such as in `ilmo.tietokilta.fi` the definition won't be rendered at all and will function like a comment. You may still add the traditional divider with `---` after each language definition and it will look nice on both versions.

- closes #484 

### Before submitting the PR, please make sure you do the following

- [x] If your PR is related to a previously discussed issue, please [link to it](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue) here.
- [x] Prefix your PR title with feat:, fix:, chore:, or docs:.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Make sure the commit history is linear, up-to-date with main branch and does not contain any erroneous changes

### Formatting and linting

- [x] Format code with `pnpm format` and lint the project with `pnpm lint`
