### PR TITLE
fix: committee members grid layout on chrome browsers after update

### DIFF
--- a/apps/web/src/components/committee-card/index.tsx
+++ b/apps/web/src/components/committee-card/index.tsx
@@ -48,6 +48,9 @@ function CommitteeMemberCard({
                 className="flex items-center gap-1"
                 href={`mailto:${committeeMember.email}`}
               >
+                <span className="sr-only">
+                  {committeeMember.name} Email: {committeeMember.email}
+                </span>
                 <GmailIcon className="size-6 shrink-0" />
               </a>
             ) : null}
@@ -60,6 +63,10 @@ function CommitteeMemberCard({
                 rel="noopener noreferrer"
                 target="_blank"
               >
+                <span className="sr-only">
+                  {committeeMember.name} Telegram:{" "}
+                  {parseTG(committeeMember.telegramUsername)}
+                </span>
                 <TelegramIcon className="size-6 shrink-0" />
               </a>
             ) : null}

--- a/apps/web/src/components/committee-card/index.tsx
+++ b/apps/web/src/components/committee-card/index.tsx
@@ -41,7 +41,7 @@ function CommitteeMemberCard({
         <span className="text-sm">
           {insertSoftHyphens(committeeMember.title)}
         </span>
-        <div className="flex items-center justify-center space-x-2">
+        <span className="flex items-center justify-center space-x-2">
           <span className="m-1 text-sm">
             {committeeMember.email ? (
               <a
@@ -64,7 +64,7 @@ function CommitteeMemberCard({
               </a>
             ) : null}
           </span>
-        </div>
+        </span>
       </p>
     </li>
   );

--- a/apps/web/src/components/committee-card/index.tsx
+++ b/apps/web/src/components/committee-card/index.tsx
@@ -91,7 +91,7 @@ export function CommitteeCard({
         !isTightLayout && "md:-mx-8 lg:-mx-32 xl:-mx-48 2xl:-mx-64",
       )}
     >
-      <details open className="group contents">
+      <details open className="group w-full">
         <summary className="absolute left-0 top-0 flex w-full cursor-pointer justify-between border-b-2 border-gray-900 bg-gray-100 p-2 [&::-webkit-details-marker]:hidden [&::marker]:hidden">
           <span className="flex w-5 gap-1 sm:w-8">
             <span className="bg-secondary-600 size-2 rounded-full border border-gray-900 sm:size-3" />


### PR DESCRIPTION
## Description

- fix: committee members grid layout on chrome browsers after update
- fix: add accessible link text to committee member email+tg links
- fix: invalid dom nesting with committee member email+tg links


### Before submitting the PR, please make sure you do the following

- [ ] If your PR is related to a previously discussed issue, please [link to it](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue) here.
- [x] Prefix your PR title with feat:, fix:, chore:, or docs:.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Make sure the commit history is linear, up-to-date with main branch and does not contain any erroneous changes

### Formatting and linting

- [x] Format code with `pnpm format` and lint the project with `pnpm lint`
