### PR TITLE
fix: restrict media to only image mime types

### DIFF
--- a/apps/cms/src/collections/media.ts
+++ b/apps/cms/src/collections/media.ts
@@ -22,6 +22,8 @@ export const Media = {
     staticDir: !useCloudStorage()
       ? path.resolve(__dirname, "../../uploads/media")
       : undefined,
+    // For audio and _especially_ video, please redirect to using something like YouTube
+    mimeTypes: ["image/*"],
   },
   fields: [
     {


### PR DESCRIPTION
## Description

The Lexical Serializer code currently expects that the files are images, and we anyways
don't want to support hosting videos directly, but instead use external services (e.g. YouTube) for video hosting.

### Before submitting the PR, please make sure you do the following

- [ ] If your PR is related to a previously discussed issue, please [link to it](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue) here.
- [x] Prefix your PR title with feat:, fix:, chore:, or docs:.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Make sure the commit history is linear, up-to-date with main branch and does not contain any erroneous changes

### Formatting and linting

- [x] Format code with `pnpm format` and lint the project with `pnpm lint`
