### PR TITLE
feat: Add committee hiding option

### DIFF
--- a/apps/cms/src/collections/committees/committees.ts
+++ b/apps/cms/src/collections/committees/committees.ts
@@ -37,6 +37,12 @@ export const Committees = {
       localized: true,
     },
     {
+      name: "hidden",
+      type: "checkbox",
+      defaultValue: false,
+      required: true,
+    },
+    {
       name: "committeeMembers",
       type: "array",
       required: true,

--- a/apps/cms/src/util/import.ts
+++ b/apps/cms/src/util/import.ts
@@ -111,6 +111,7 @@ async function createCommittee(
       year: guildYear,
       name: committeeName,
       committeeMembers,
+      hidden: false,
     },
     locale: "fi",
     req: transactionID

--- a/apps/web/src/components/committee-list/index.tsx
+++ b/apps/web/src/components/committee-list/index.tsx
@@ -11,7 +11,7 @@ export async function CommitteeList({
 }): Promise<JSX.Element | null> {
   const locale = await getCurrentLocale();
   const committees = await fetchCommittees({
-    where: { year: { equals: year } },
+    where: { year: { equals: year }, hidden: { not_equals: true } },
     locale,
   });
 

--- a/apps/web/src/lib/api/committees.ts
+++ b/apps/web/src/lib/api/committees.ts
@@ -2,6 +2,6 @@ import type { Committee } from "@tietokilta/cms-types/payload";
 import { getAllCollectionItems } from "./fetcher";
 
 export const fetchCommittees = getAllCollectionItems<
-  { where: { year: { equals: string } } },
+  { where: { year: { equals: string }; hidden: { not_equals: boolean } } },
   Committee[]
 >("committees");

--- a/apps/web/src/lib/api/committees.ts
+++ b/apps/web/src/lib/api/committees.ts
@@ -2,6 +2,7 @@ import type { Committee } from "@tietokilta/cms-types/payload";
 import { getAllCollectionItems } from "./fetcher";
 
 export const fetchCommittees = getAllCollectionItems<
+  // using not_equals filter for backwards compatibility with old committees
   { where: { year: { equals: string }; hidden: { not_equals: boolean } } },
   Committee[]
 >("committees");

--- a/packages/cms-types/payload.ts
+++ b/packages/cms-types/payload.ts
@@ -519,6 +519,7 @@ export interface Committee {
     | '1987'
     | '1986';
   name: string;
+  hidden: boolean;
   committeeMembers: {
     committeeMember?: (string | null) | CommitteeMember;
     id?: string | null;

--- a/packages/cms-types/schema.gql
+++ b/packages/cms-types/schema.gql
@@ -4842,6 +4842,7 @@ type Committee {
   id: String
   year: Committee_year!
   name: String
+  hidden: Boolean!
   committeeMembers: [Committee_CommitteeMembers!]!
   updatedAt: DateTime
   createdAt: DateTime
@@ -4912,6 +4913,7 @@ type Committees {
 input Committee_where {
   year: Committee_year_operator
   name: Committee_name_operator
+  hidden: Committee_hidden_operator
   committeeMembers__committeeMember: Committee_committeeMembers__committeeMember_operator
   committeeMembers__id: Committee_committeeMembers__id_operator
   updatedAt: Committee_updatedAt_operator
@@ -4982,6 +4984,11 @@ input Committee_name_operator {
   all: [String]
 }
 
+input Committee_hidden_operator {
+  equals: Boolean
+  not_equals: Boolean
+}
+
 input Committee_committeeMembers__committeeMember_operator {
   equals: JSON
   not_equals: JSON
@@ -5038,6 +5045,7 @@ input Committee_id_operator {
 input Committee_where_and {
   year: Committee_year_operator
   name: Committee_name_operator
+  hidden: Committee_hidden_operator
   committeeMembers__committeeMember: Committee_committeeMembers__committeeMember_operator
   committeeMembers__id: Committee_committeeMembers__id_operator
   updatedAt: Committee_updatedAt_operator
@@ -5050,6 +5058,7 @@ input Committee_where_and {
 input Committee_where_or {
   year: Committee_year_operator
   name: Committee_name_operator
+  hidden: Committee_hidden_operator
   committeeMembers__committeeMember: Committee_committeeMembers__committeeMember_operator
   committeeMembers__id: Committee_committeeMembers__id_operator
   updatedAt: Committee_updatedAt_operator
@@ -5074,6 +5083,7 @@ type committeesDocAccess {
 type CommitteesDocAccessFields {
   year: CommitteesDocAccessFields_year
   name: CommitteesDocAccessFields_name
+  hidden: CommitteesDocAccessFields_hidden
   committeeMembers: CommitteesDocAccessFields_committeeMembers
   updatedAt: CommitteesDocAccessFields_updatedAt
   createdAt: CommitteesDocAccessFields_createdAt
@@ -5122,6 +5132,29 @@ type CommitteesDocAccessFields_name_Update {
 }
 
 type CommitteesDocAccessFields_name_Delete {
+  permission: Boolean!
+}
+
+type CommitteesDocAccessFields_hidden {
+  create: CommitteesDocAccessFields_hidden_Create
+  read: CommitteesDocAccessFields_hidden_Read
+  update: CommitteesDocAccessFields_hidden_Update
+  delete: CommitteesDocAccessFields_hidden_Delete
+}
+
+type CommitteesDocAccessFields_hidden_Create {
+  permission: Boolean!
+}
+
+type CommitteesDocAccessFields_hidden_Read {
+  permission: Boolean!
+}
+
+type CommitteesDocAccessFields_hidden_Update {
+  permission: Boolean!
+}
+
+type CommitteesDocAccessFields_hidden_Delete {
   permission: Boolean!
 }
 
@@ -12324,6 +12357,7 @@ type committeesAccess {
 type CommitteesFields {
   year: CommitteesFields_year
   name: CommitteesFields_name
+  hidden: CommitteesFields_hidden
   committeeMembers: CommitteesFields_committeeMembers
   updatedAt: CommitteesFields_updatedAt
   createdAt: CommitteesFields_createdAt
@@ -12372,6 +12406,29 @@ type CommitteesFields_name_Update {
 }
 
 type CommitteesFields_name_Delete {
+  permission: Boolean!
+}
+
+type CommitteesFields_hidden {
+  create: CommitteesFields_hidden_Create
+  read: CommitteesFields_hidden_Read
+  update: CommitteesFields_hidden_Update
+  delete: CommitteesFields_hidden_Delete
+}
+
+type CommitteesFields_hidden_Create {
+  permission: Boolean!
+}
+
+type CommitteesFields_hidden_Read {
+  permission: Boolean!
+}
+
+type CommitteesFields_hidden_Update {
+  permission: Boolean!
+}
+
+type CommitteesFields_hidden_Delete {
   permission: Boolean!
 }
 
@@ -16197,6 +16254,7 @@ enum CommitteeMemberUpdate_guildYear_MutationInput {
 input mutationCommitteeInput {
   year: Committee_year_MutationInput!
   name: String
+  hidden: Boolean
   committeeMembers: [mutationCommittee_CommitteeMembersInput!]
   updatedAt: String
   createdAt: String
@@ -16253,6 +16311,7 @@ input mutationCommittee_CommitteeMembersInput {
 input mutationCommitteeUpdateInput {
   year: CommitteeUpdate_year_MutationInput
   name: String
+  hidden: Boolean
   committeeMembers: [mutationCommitteeUpdate_CommitteeMembersInput]
   updatedAt: String
   createdAt: String


### PR DESCRIPTION
## Description

The equality page needs a committee component that shouldn't be visible in the actual committee list. This adds a checkbox in the CMS to hide a committee from the committee list pages.

### Before submitting the PR, please make sure you do the following

- [✔️] telegram conversation 👍 
- [✔️] Prefix your PR title with feat:, fix:, chore:, or docs:.
- [✔️] This message body should clearly illustrate what problems it solves.
- [✔️] Make sure the commit history is linear, up-to-date with main branch and does not contain any erroneous changes

### Formatting and linting

- [✔️] Format code with `pnpm format` and lint the project with `pnpm lint`
