### PR TITLE
fix: Center align TG/email button on committee member card

### DIFF
--- a/apps/web/src/components/committee-card/index.tsx
+++ b/apps/web/src/components/committee-card/index.tsx
@@ -42,8 +42,8 @@ function CommitteeMemberCard({
           {insertSoftHyphens(committeeMember.title)}
         </span>
         <span className="flex items-center justify-center space-x-2">
-          <span className="m-1 text-sm">
-            {committeeMember.email ? (
+          {committeeMember.email ? (
+            <span className="m-1 text-sm">
               <a
                 className="flex items-center gap-1"
                 href={`mailto:${committeeMember.email}`}
@@ -53,10 +53,10 @@ function CommitteeMemberCard({
                 </span>
                 <GmailIcon className="size-6 shrink-0" />
               </a>
-            ) : null}
-          </span>
-          <span className="m-1 text-sm">
-            {committeeMember.telegramUsername ? (
+            </span>
+          ) : null}
+          {committeeMember.telegramUsername ? (
+            <span className="m-1 text-sm">
               <a
                 className="flex items-center gap-1"
                 href={`https://t.me/${parseTG(committeeMember.telegramUsername)}`}
@@ -69,8 +69,8 @@ function CommitteeMemberCard({
                 </span>
                 <TelegramIcon className="size-6 shrink-0" />
               </a>
-            ) : null}
-          </span>
+            </span>
+          ) : null}
         </span>
       </p>
     </li>


### PR DESCRIPTION
- Previously the `<span>` was created for both buttons, now it's conditional and single buttons are centered correctly

## Description

- Previous: 
![image](https://github.com/user-attachments/assets/0d72ff48-da08-44dd-b047-9aae64cb08df)
- Fixed:
![image](https://github.com/user-attachments/assets/52836333-89a3-4bc9-b5cc-bd817f12da27)


### Before submitting the PR, please make sure you do the following

- [x] If your PR is related to a previously discussed issue, please [link to it](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue) here.
- [x] Prefix your PR title with feat:, fix:, chore:, or docs:.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Make sure the commit history is linear, up-to-date with main branch and does not contain any erroneous changes

### Formatting and linting

- [x] Format code with `pnpm format` and lint the project with `pnpm lint`
