### PR TITLE
fix: send invoices straight from client instead of through next.js

### DIFF
--- a/apps/web/src/lib/api/external/laskugeneraattori/actions.ts
+++ b/apps/web/src/lib/api/external/laskugeneraattori/actions.ts
@@ -1,4 +1,4 @@
-"use server";
+"use client";
 
 import {
   type InvoiceGeneratorFormState,


### PR DESCRIPTION
## Description

Title pretty much. Problem was that Next.js as [`bodySizeLimit`](https://nextjs.org/docs/app/api-reference/config/next-config-js/serverActions#bodysizelimit) that
gets hit when sending larger images. Invoice generator already has a size limit of its own so
we don't need to use next for limiting this. Fix for this is to send invoices straight to
invoice generator.

### Before submitting the PR, please make sure you do the following

- [x] If your PR is related to a previously discussed issue, please [link to it](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue) here.
- [x] Prefix your PR title with feat:, fix:, chore:, or docs:.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Make sure the commit history is linear, up-to-date with main branch and does not contain any erroneous changes

### Formatting and linting

- [x] Format code with `pnpm format` and lint the project with `pnpm lint`
