### PR TITLE
fix: Infoscreen allergy information overflow

### DIFF
--- a/apps/web/src/components/infoscreen/kanttiinit/index.tsx
+++ b/apps/web/src/components/infoscreen/kanttiinit/index.tsx
@@ -65,7 +65,7 @@ export async function KanttiinitCombined() {
           ))}
         </div>
       </div>
-      <div className="absolute bottom-0 z-10 h-[5%] w-full content-center text-center align-text-bottom">
+      <div className="absolute inset-x-0 bottom-0 z-10 h-[5%] content-center text-center align-text-bottom">
         {t("allergeenit")}
       </div>
     </div>


### PR DESCRIPTION
- Allergy information on infoscreen was too wide, and caused scrollbar to appear on infoscreen. This is now fixed

### Before submitting the PR, please make sure you do the following

- [x] If your PR is related to a previously discussed issue, please [link to it](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue) here.
- [x] Prefix your PR title with feat:, fix:, chore:, or docs:.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Make sure the commit history is linear, up-to-date with main branch and does not contain any erroneous changes

### Formatting and linting

- [x] Format code with `pnpm format` and lint the project with `pnpm lint`
