### PR TITLE
feat: add highlight card block with rich-text

### DIFF
--- a/apps/cms/src/blocks/highlight-card.ts
+++ b/apps/cms/src/blocks/highlight-card.ts
@@ -1,0 +1,14 @@
+import { lexicalEditor } from "@payloadcms/richtext-lexical";
+import type { Block } from "payload/types";
+
+export const HighlightCard = {
+  slug: "highlight-card",
+  fields: [
+    {
+      name: "content",
+      type: "richText",
+      editor: lexicalEditor({}),
+      required: true,
+    },
+  ],
+} satisfies Block;

--- a/apps/cms/src/payload.config.ts
+++ b/apps/cms/src/payload.config.ts
@@ -50,6 +50,7 @@ import { NewsItems } from "./collections/weekly-newsletters/news-items";
 import { ActionsLink, ActionsView } from "./views/actions-view";
 import { ImageLinkGrid } from "./blocks/image-link-grid";
 import { GoogleForm } from "./blocks/google-form";
+import { HighlightCard } from "./blocks/highlight-card";
 import { EditorInChief } from "./blocks/editor-in-chief";
 import { InvoiceGenerator } from "./blocks/invoice-generator";
 import { Partners } from "./collections/partners";
@@ -179,6 +180,7 @@ export default buildConfig({
           CommitteesInYear,
           ImageLinkGrid,
           GoogleForm,
+          HighlightCard,
           EditorInChief,
           InvoiceGenerator,
           PartnersBlock,

--- a/apps/web/src/components/highlight-card/index.tsx
+++ b/apps/web/src/components/highlight-card/index.tsx
@@ -1,0 +1,25 @@
+import {
+  type Node,
+  type HighlightCardBlockNode,
+} from "@tietokilta/cms-types/lexical";
+import { Card } from "@tietokilta/ui";
+import React from "react";
+
+interface RendererProps {
+  nodes: Node[];
+}
+
+export function HighlightCard({
+  content,
+  Renderer,
+}: {
+  content: HighlightCardBlockNode["fields"]["content"];
+  // Pass LexicalSerializer as a prop, otherwise introduces a cyclical import
+  Renderer: React.ComponentType<RendererProps>;
+}) {
+  return (
+    <Card className="not-prose text-black">
+      <Renderer nodes={content.root.children} />
+    </Card>
+  );
+}

--- a/apps/web/src/components/lexical/lexical-serializer.tsx
+++ b/apps/web/src/components/lexical/lexical-serializer.tsx
@@ -11,6 +11,7 @@ import Link from "next/link";
 import { type Media } from "@tietokilta/cms-types/payload";
 import type { JSX } from "react";
 import { PartnerLogos } from "@components/partner-logos";
+import { HighlightCard } from "@components/highlight-card";
 import {
   cn,
   insertSoftHyphens,
@@ -130,11 +131,11 @@ export function LexicalSerializer({ nodes }: { nodes: Node[] }): JSX.Element {
             const Tag = node.tag as Heading;
 
             return (
-              <Link href={`#${stringToId(lexicalNodeToTextContent(node))}`}>
-                <Tag
-                  id={stringToId(lexicalNodeToTextContent(node))}
-                  key={index}
-                >
+              <Link
+                href={`#${stringToId(lexicalNodeToTextContent(node))}`}
+                key={index}
+              >
+                <Tag id={stringToId(lexicalNodeToTextContent(node))}>
                   {serializedChildren}
                 </Tag>
               </Link>
@@ -324,6 +325,14 @@ function Block({ node }: { node: BlockNode }) {
     }
     case "google-form": {
       return <GoogleForm link={node.fields.link} />;
+    }
+    case "highlight-card": {
+      return (
+        <HighlightCard
+          content={node.fields.content}
+          Renderer={LexicalSerializer}
+        />
+      );
     }
     case "editor-in-chief": {
       return <EditorInChief name={node.fields.name} type={node.fields.type} />;

--- a/packages/cms-types/lexical.ts
+++ b/packages/cms-types/lexical.ts
@@ -190,6 +190,14 @@ export type GoogleFormBlockNode = BaseBlockNode & {
   };
 };
 
+export type HighlightCardBlockNode = BaseBlockNode & {
+  fields: BaseBlockFields & {
+    blockType: "highlight-card";
+    content: EditorState;
+    another: number;
+  };
+};
+
 export type EditorInChiefBlockNode = BaseBlockNode & {
   fields: BaseBlockFields & {
     blockType: "editor-in-chief";
@@ -216,6 +224,7 @@ export type BlockNode =
   | CommitteesYearBlockNode
   | ImageLinkGridBlockNode
   | GoogleFormBlockNode
+  | HighlightCardBlockNode
   | EditorInChiefBlockNode
   | InvoiceGeneratorBlockNode
   | PartnersBlockNode;


### PR DESCRIPTION
## Description

Fixes #485 

Adds a rich-text highlight card block into CMS and web

### Before submitting the PR, please make sure you do the following

- [x] If your PR is related to a previously discussed issue, please [link to it](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue) here.
- [x] Prefix your PR title with feat:, fix:, chore:, or docs:.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Make sure the commit history is linear, up-to-date with main branch and does not contain any erroneous changes

### Formatting and linting

- [x] Format code with `pnpm format` and lint the project with `pnpm lint`
