### PR TITLE
fix: strip markdown syntax from event preview image

### DIFF
--- a/apps/web/src/app/[locale]/(main)/events/[slug]/opengraph-image.tsx
+++ b/apps/web/src/app/[locale]/(main)/events/[slug]/opengraph-image.tsx
@@ -71,7 +71,9 @@ export default async function Image(props: PageProps) {
   const tikLogoSrc = Uint8Array.from(tikLogoData).buffer;
 
   const title = getLocalizedEventTitle(event.data.title, locale);
-  const description =  (await remark().use(stripMarkdown).process(event.data.description)).toString()
+  const description = (
+    await remark().use(stripMarkdown).process(event.data.description)
+  ).toString();
 
   return new ImageResponse(
     (

--- a/apps/web/src/app/[locale]/(main)/events/[slug]/opengraph-image.tsx
+++ b/apps/web/src/app/[locale]/(main)/events/[slug]/opengraph-image.tsx
@@ -3,6 +3,8 @@ import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { ImageResponse } from "next/og";
 import { notFound } from "next/navigation";
+import stripMarkdown from "strip-markdown";
+import { remark } from "remark";
 import { getCurrentLocale } from "@locales/server";
 import { fetchEvent } from "@lib/api/external/ilmomasiina";
 import { formatDateTime, getLocalizedEventTitle } from "@lib/utils";
@@ -69,7 +71,7 @@ export default async function Image(props: PageProps) {
   const tikLogoSrc = Uint8Array.from(tikLogoData).buffer;
 
   const title = getLocalizedEventTitle(event.data.title, locale);
-  const description = event.data.description;
+  const description =  (await remark().use(stripMarkdown).process(event.data.description)).toString()
 
   return new ImageResponse(
     (


### PR DESCRIPTION
## Description

- Fixes #689 by removing markdown syntax from the event preview OpenGraph image.

### Before submitting the PR, please make sure you do the following

- [x] If your PR is related to a previously discussed issue, please [link to it](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue) here.
- [x] Prefix your PR title with feat:, fix:, chore:, or docs:.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Make sure the commit history is linear, up-to-date with main branch and does not contain any erroneous changes

### Formatting and linting

- [x] Format code with `pnpm format` and lint the project with `pnpm lint`
