### PR TITLE
feat(invoice-generator): enforce 24MB client-side payload size limit

### DIFF
--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/web/src/components/invoice-generator/index.tsx
+++ b/apps/web/src/components/invoice-generator/index.tsx
@@ -21,6 +21,7 @@ import {
 } from "../../locales/client";
 import { SaveAction } from "../../lib/api/external/laskugeneraattori/actions";
 import { type InvoiceGeneratorFormState } from "../../lib/api/external/laskugeneraattori/index";
+
 const MAX_PAYLOAD_SIZE = 24 * 1024 * 1024; // 24MB in bytes
 
 interface GenericFieldProps extends InputHTMLAttributes<HTMLInputElement> {
@@ -311,9 +312,11 @@ function InvoiceGeneratorForm() {
     const formData = new FormData(event.target);
 
     const payloadSize = calculateFormDataSize(formData);
-    
-    if(payloadSize > MAX_PAYLOAD_SIZE){
-      toast.error("Total form size exceeds 24MB limit. Please remove some files.");
+
+    if (payloadSize > MAX_PAYLOAD_SIZE) {
+      toast.error(
+        "Total form size exceeds 24MB limit. Please remove some files.",
+      );
       return;
     }
 
@@ -322,11 +325,11 @@ function InvoiceGeneratorForm() {
     });
   };
 
-  const calculateFormDataSize = (formData: FormData):number => {
+  const calculateFormDataSize = (formData: FormData): number => {
     let totalSize = 0;
 
     formData.forEach((value, key) => {
-    // Add size of the key
+      // Add size of the key
       totalSize += new Blob([key]).size;
 
       if (value instanceof File) {
@@ -338,8 +341,7 @@ function InvoiceGeneratorForm() {
       }
     });
     return totalSize;
-  }
-
+  };
 
   useEffect(() => {
     const errorFields = state?.errors ? Object.keys(state.errors) : [];


### PR DESCRIPTION
## Description

- Added client-side validation to enforce a maximum payload size of **24MB** in `invoice-generator.tsx`.
- Before form submission, the total size of file attachments and text inputs is calculated.
- If the payload exceeds 24MB:
  - Submission is blocked.
  - A friendly toast error message is displayed.
- Prevents backend from returning `413 Payload Too Large` errors.

**Related Issue**
Closes #744 

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

### Before submitting the PR, please make sure you do the following

- [ ] If your PR is related to a previously discussed issue, please [link to it](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue) here.
- [ ] Prefix your PR title with feat:, fix:, chore:, or docs:.
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Make sure the commit history is linear, up-to-date with main branch and does not contain any erroneous changes

### Formatting and linting

- [ ] Format code with `pnpm format` and lint the project with `pnpm lint`
