### PR TITLE
fix: prefer type guards derived with less type casting

### DIFF
--- a/apps/web/src/app/[locale]/(main)/page.tsx
+++ b/apps/web/src/app/[locale]/(main)/page.tsx
@@ -2,12 +2,13 @@ import { type Metadata } from "next";
 import type { EditorState } from "@lexical-types";
 import type { News, Page as CMSPage } from "@payload-types";
 import { EventsDisplay } from "@components/events-display";
-import { Hero, type ImageWithPhotographer } from "@components/hero";
+import { Hero } from "@components/hero";
 import { LexicalSerializer } from "@components/lexical/lexical-serializer";
 import { fetchLandingPage } from "@lib/api/landing-page";
 import { AnnouncementCard } from "@components/announcement-card";
 import { getCurrentLocale } from "@locales/server";
 import AprilFoolsAlert from "@components/april-fools/april-fools-alert";
+import { type NonNullableKeys } from "@lib/utils";
 
 function Content({ content }: { content?: EditorState }) {
   if (!content) return null;
@@ -52,7 +53,10 @@ export default async function Home(props: {
               ? null
               : { url: image?.url, photographer: image?.photographer },
           )
-          .filter((url): url is ImageWithPhotographer => Boolean(url))}
+          .filter(
+            (img): img is NonNullableKeys<NonNullable<typeof img>, "url"> =>
+              Boolean(img?.url),
+          )}
         texts={landingPageData.heroTexts
           .map(({ text }) => (typeof text === "string" ? text : null))
           .filter((url): url is string => Boolean(url))}

--- a/apps/web/src/components/mobile-nav/index.tsx
+++ b/apps/web/src/components/mobile-nav/index.tsx
@@ -8,7 +8,7 @@ import {
   SheetTrigger,
 } from "@tietokilta/ui";
 import Link from "next/link";
-import type { LinkRowBlock, Media, PartnersRowBlock } from "@payload-types";
+import type { Media } from "@payload-types";
 import { fetchFooter } from "../../lib/api/footer";
 import { fetchMainNavigation } from "../../lib/api/main-navigation";
 import { cn } from "../../lib/utils";
@@ -36,11 +36,13 @@ export async function MobileNav({
 
   const links = mainNav.items;
   const footerLinks = footer.layout.filter(
-    (block): block is LinkRowBlock => block.blockType === "link-row",
+    (block): block is Extract<typeof block, { blockType: "link-row" }> =>
+      block.blockType === "link-row",
   );
 
   const footerSponsors = footer.layout.filter(
-    (block): block is PartnersRowBlock => block.blockType === "partners-row",
+    (block): block is Extract<typeof block, { blockType: "partners-row" }> =>
+      block.blockType === "partners-row",
   );
   const navLogo = mainNav.logo as Media;
 

--- a/apps/web/src/controllers/utils/tg-parser.ts
+++ b/apps/web/src/controllers/utils/tg-parser.ts
@@ -168,7 +168,9 @@ export const parseToc = (
           })),
         }
       : null,
-  ].filter((itemOrNull): itemOrNull is TocItem => Boolean(itemOrNull));
+  ].filter((itemOrNull): itemOrNull is NonNullable<typeof itemOrNull> =>
+    Boolean(itemOrNull),
+  );
   toc.forEach((item, index) => {
     const parentOrder = `${(index + 1).toString()}.`;
     tgString += `${parentOrder} ${item.text}\n`;

--- a/apps/web/src/lib/utils.ts
+++ b/apps/web/src/lib/utils.ts
@@ -328,3 +328,7 @@ export function assertUnreachable(value: never) {
  */
 // eslint-disable-next-line @typescript-eslint/no-empty-function, @typescript-eslint/naming-convention, @typescript-eslint/no-unnecessary-type-parameters -- used for type assertion
 export function assertType<_T>(_val: _T) {}
+
+export type NonNullableKeys<T, K extends keyof T> = T & {
+  [P in K]-?: NonNullable<T[P]>;
+};


### PR DESCRIPTION
## Description

- fix: prefer type guards derived with less type casting
	- this hopefully prevents more bugs like #751 from popping up
	- there's no validation for `type is Type` return type, so at least prefer to derive it from the actual types

### Before submitting the PR, please make sure you do the following

- [ ] If your PR is related to a previously discussed issue, please [link to it](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue) here.
- [x] Prefix your PR title with feat:, fix:, chore:, or docs:.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Make sure the commit history is linear, up-to-date with main branch and does not contain any erroneous changes

### Formatting and linting

- [x] Format code with `pnpm format` and lint the project with `pnpm lint`
