### PR TITLE
fix(infoscreen): don't unload infoscreen pages

### DIFF
--- a/apps/web/src/components/infoscreen/infoscreen-switcher/index.tsx
+++ b/apps/web/src/components/infoscreen/infoscreen-switcher/index.tsx
@@ -1,5 +1,4 @@
 "use client";
-
 import React, { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { isTruthy } from "remeda";
@@ -19,14 +18,13 @@ export default function InfoScreenSwitcher({
       setCurrent((prev) => (prev + 1) % count);
       router.refresh();
     };
-
     const intervalId = setInterval(setNextChild, 15000); // Change screen every x seconds
 
-    // Clear the interval when the component unmounts
     return () => {
       clearInterval(intervalId);
     };
   }, [count, router]);
+
   if (childrenArray.length === 0) {
     return (
       <div className="flex h-full flex-col">
@@ -35,5 +33,20 @@ export default function InfoScreenSwitcher({
     );
   }
 
-  return <>{childrenArray[current]}</>;
+  return (
+    <>
+      {childrenArray.map((child, index) => (
+        <div
+          key={index}
+          style={{
+            display: index === current ? "block" : "none",
+            width: "100%",
+            height: "100%",
+          }}
+        >
+          {child}
+        </div>
+      ))}
+    </>
+  );
 }


### PR DESCRIPTION
## Description

Don't unload infoscreen pages between cycles. Reloading them every time takes time and looks stupid

### Before submitting the PR, please make sure you do the following

- [ ] If your PR is related to a previously discussed issue, please [link to it](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue) here.
- [ ] Prefix your PR title with feat:, fix:, chore:, or docs:.
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Make sure the commit history is linear, up-to-date with main branch and does not contain any erroneous changes

### Formatting and linting

- [ ] Format code with `pnpm format` and lint the project with `pnpm lint`
