### PR TITLE
fix: grayscale logo usage in footer

### DIFF
--- a/apps/web/src/components/partner-logos/index.tsx
+++ b/apps/web/src/components/partner-logos/index.tsx
@@ -6,6 +6,7 @@ import { ImageLinkGrid } from "@components/image-link-grid";
 import { fetchPartners } from "@lib/api/partners";
 import { getCurrentLocale } from "@locales/server";
 import { Link as MobileLink } from "@components/mobile-nav/link";
+import { cn } from "@lib/utils";
 
 export async function PartnerLogos({
   statuses,
@@ -29,7 +30,7 @@ export async function PartnerLogos({
     // Use grayscale logo only in footer contexts (row/mobileRow), fallback to regular logo
     const image =
       type === "row" || type === "mobileRow"
-        ? (partner.logoGrayscale as Media | null) ?? (partner.logo as Media)
+        ? ((partner.logoGrayscale as Media | null) ?? (partner.logo as Media))
         : (partner.logo as Media);
     return { image, externalLink: partner.externalLink };
   });
@@ -39,7 +40,10 @@ export async function PartnerLogos({
       <ul className="flex flex-wrap items-center justify-center gap-4">
         {logos.map((logo) => (
           <li
-            className={`relative flex items-center justify-center ${type === "row" ? "h-16 max-w-48" : "h-24 max-w-60 p-2"}`}
+            className={cn(
+              "relative flex items-center justify-center",
+              type === "row" ? "h-16 max-w-48" : "h-24 max-w-60 p-2",
+            )}
             key={logo.image.id}
           >
             <Link


### PR DESCRIPTION
- Grayscale logos should only be used in desktop and mobile footers
- Partner display blocks and infoscreen should use regular color logos
- Fixes incorrect application of grayscale to all partner logo contexts

## Description

- ...

### Before submitting the PR, please make sure you do the following

- [ ] If your PR is related to a previously discussed issue, please [link to it](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue) here.
- [ ] Prefix your PR title with feat:, fix:, chore:, or docs:.
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Make sure the commit history is linear, up-to-date with main branch and does not contain any erroneous changes

### Formatting and linting

- [ ] Format code with `pnpm format` and lint the project with `pnpm lint`
