### PR TITLE
feat: include past events in ICS calendar feed

### DIFF
--- a/apps/web/src/app/next_api/ilmo-calendar/route.ts
+++ b/apps/web/src/app/next_api/ilmo-calendar/route.ts
@@ -11,7 +11,10 @@ export async function GET(request: NextRequest) {
   // For invalid or missing language versions such as "", event localization gracefully
   // falls back to the default language version.
   const locale = request.nextUrl.searchParams.get("lang") ?? "";
-  const events = await fetchEvents(locale);
+  // Use maxAge to fetch all historical events (180 days is the maximum for default Ilmomasiina config)
+  // This prevents past events from being deleted from users' calendar subscriptions
+  const maxAge = 180; // days
+  const events = await fetchEvents(locale, maxAge);
 
   // Set the host to the one in the request headers
   // We trust the middleware to set the host header correctly in Azure


### PR DESCRIPTION
Add maxAge parameter (180 days) to ICS endpoint to fetch historical events.
This prevents past events from being deleted from users' calendar subscriptions.