### PR TITLE
fix: show grayscale version of Main Partner logo on infoscreen

### DIFF
--- a/apps/web/src/components/partner-logos/index.tsx
+++ b/apps/web/src/components/partner-logos/index.tsx
@@ -27,9 +27,9 @@ export async function PartnerLogos({
   }
 
   const logos = partners.map((partner) => {
-    // Use grayscale logo only in footer contexts (row/mobileRow), fallback to regular logo
+    // Use grayscale logo only in footer contexts (row/mobileRow) and in infoscreen header, fallback to regular logo
     const image =
-      type === "row" || type === "mobileRow"
+      type === "row" || type === "mobileRow" || type === "infoscreen"
         ? ((partner.logoGrayscale as Media | null) ?? (partner.logo as Media))
         : (partner.logo as Media);
     return { image, externalLink: partner.externalLink };


### PR DESCRIPTION
## Description

- Fix infoscreen to show grayscale version of Main Partner logos when available

### Before submitting the PR, please make sure you do the following

- [ ] If your PR is related to a previously discussed issue, please [link to it](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue) here.
- [ ] Prefix your PR title with feat:, fix:, chore:, or docs:.
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Make sure the commit history is linear, up-to-date with main branch and does not contain any erroneous changes

### Formatting and linting

- [ ] Format code with `pnpm format` and lint the project with `pnpm lint`
