### PR TITLE
fix: rename Ayy to AYY in newsletters

### DIFF
--- a/apps/web/src/controllers/utils/tg-parser.ts
+++ b/apps/web/src/controllers/utils/tg-parser.ts
@@ -81,7 +81,7 @@ export const parseToc = (
     en: {
       calendar: "Calendar",
       guild: "Guild",
-      "ayy-aalto": "Ayy & Aalto",
+      "ayy-aalto": "AYY & Aalto",
       other: "Other",
       "bottom-corner": "Bottom Corner",
       read: "Read",
@@ -92,7 +92,7 @@ export const parseToc = (
     fi: {
       calendar: "Kalenteri",
       guild: "Kilta",
-      "ayy-aalto": "Ayy & Aalto",
+      "ayy-aalto": "AYY & Aalto",
       other: "Muut",
       "bottom-corner": "Pohjanurkkaus",
       read: "Lue",

--- a/apps/web/src/emails/newsletter.tsx
+++ b/apps/web/src/emails/newsletter.tsx
@@ -26,7 +26,7 @@ export function Newsletter({
     en: {
       calendar: "Calendar",
       guild: "Guild",
-      "ayy-aalto": "Ayy & Aalto",
+      "ayy-aalto": "AYY & Aalto",
       other: "Other",
       "bottom-corner": "Bottom Corner",
       read: "Read",
@@ -38,7 +38,7 @@ export function Newsletter({
     fi: {
       calendar: "Kalenteri",
       guild: "Kilta",
-      "ayy-aalto": "Ayy & Aalto",
+      "ayy-aalto": "AYY & Aalto",
       other: "Muut",
       "bottom-corner": "Pohjanurkkaus",
       read: "Lue",

--- a/apps/web/src/fields/news-item-category.ts
+++ b/apps/web/src/fields/news-item-category.ts
@@ -17,8 +17,8 @@ export const newsItemCategoryField = (
     },
     {
       label: {
-        fi: "Ayy & Aalto",
-        en: "Ayy & Aalto",
+        fi: "AYY & Aalto",
+        en: "AYY & Aalto",
       },
       value: "ayy-aalto",
     },


### PR DESCRIPTION
## Description

- Head of Communications asked for this. Emails, Telegram messages etc. have AYY written wrong.

### Before submitting the PR, please make sure you do the following

- [x] If your PR is related to a previously discussed issue, please [link to it](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue) here.
- [x] Prefix your PR title with feat:, fix:, chore:, or docs:.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Make sure the commit history is linear, up-to-date with main branch and does not contain any erroneous changes

### Formatting and linting

- [x] Format code with `pnpm format` and lint the project with `pnpm lint`
