### PR TITLE
fix: deduplicate HSL schedule arrivals and improve key consistency

### DIFF
--- a/apps/web/src/components/infoscreen/hsl-schedules/fetcher.ts
+++ b/apps/web/src/components/infoscreen/hsl-schedules/fetcher.ts
@@ -63,7 +63,6 @@ const getData = async (stop: string) => {
               realtimeArrival
               serviceDay
               trip{
-                gtfsId
                 tripHeadsign
                 routeShortName
               }
@@ -102,7 +101,6 @@ function mapStop(stop: StopHSL): Omit<Stop, "type"> {
     name: stop.name,
     arrivals: stop.stoptimesWithoutPatterns
       .map((arr: HSLStopTime) => {
-        const tripId = arr.trip.gtfsId;
         const route = arr.trip.routeShortName;
         const headSign = arr.trip.tripHeadsign;
         const arrivalTimeLocal = arr.realtimeArrival + arr.serviceDay;
@@ -112,7 +110,6 @@ function mapStop(stop: StopHSL): Omit<Stop, "type"> {
           return null;
         }
         return {
-          tripId,
           arrivalTimeUnix: arrivalTimeLocal,
           serviceDay,
           route: route ? route.replace(" ", "") : "Null",

--- a/apps/web/src/components/infoscreen/hsl-schedules/index.tsx
+++ b/apps/web/src/components/infoscreen/hsl-schedules/index.tsx
@@ -43,7 +43,7 @@ function HSLSchedule({ stop }: HSLScheduleProps) {
       <ul className="space-y-4 font-bold">
         {stop.arrivals.map((arr) => (
           <li
-            key={arr.tripId}
+            key={`${arr.route}-${arr.headSign}-${arr.arrivalTimeUnix}`}
             className="grid grid-cols-[1fr_2fr_1fr] items-center rounded-md border-2 border-(--infonayttoHSLcolor) p-3 font-mono text-gray-900 shadow-(--infonayttoHSLcolor) shadow-solid md:items-center"
           >
             <div className="text-left text-3xl text-(--infonayttoHSLcolor)">

--- a/apps/web/src/components/infoscreen/types/hsl-helper-types.ts
+++ b/apps/web/src/components/infoscreen/types/hsl-helper-types.ts
@@ -10,7 +10,6 @@ export interface HSLStopTime {
   realtimeArrival: number;
   serviceDay: number;
   trip: {
-    gtfsId: string;
     tripHeadsign: string;
     routeShortName: string;
   };
@@ -18,7 +17,6 @@ export interface HSLStopTime {
 export type StopType = "metro" | "tram" | "bus";
 
 export interface Arrival {
-  tripId: string;
   route: string;
   headSign: string;
   arrivalTimeUnix: number;


### PR DESCRIPTION
## Description

- Added deduplication logic for HSL schedule arrivals when combining results from two stops
- Uses a composite key (`route-headSign-arrivalTimeUnix`) to identify and filter duplicate arrivals
- Updated React list key in HSLSchedule component to use the same composite key format for consistency
- Prevents duplicate arrival entries from being displayed when the same bus arrives at both stops

### Why this change?

When fetching arrivals from two stops, duplicate entries could appear if the same bus arrival was returned by both API calls. This change ensures each unique arrival (identified by route, destination, and time) appears only once in the results.

The key format change (`route-headSign-fullTime` → `route-headSign-arrivalTimeUnix`) provides:
- More reliable uniqueness based on Unix timestamp instead of formatted time string
- Consistency between deduplication logic and React rendering keys
- Better performance for Set-based lookups

### Before submitting the PR, please make sure you do the following

- [ ] If your PR is related to a previously discussed issue, please [link to it](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue) here.
- [ ] Prefix your PR title with feat:, fix:, chore:, or docs:.
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Make sure the commit history is linear, up-to-date with main branch and does not contain any erroneous changes

### Formatting and linting

- [ ] Format code with `pnpm format` and lint the project with `pnpm lint`