### PR TITLE
fix: Display localized text for open quotas in event signup

### DIFF
--- a/apps/web/src/app/[locale]/(main)/events/[slug]/page.tsx
+++ b/apps/web/src/app/[locale]/(main)/events/[slug]/page.tsx
@@ -333,7 +333,11 @@ async function SignUpQuotas({ event }: { event: UserEventResponse }) {
               </span>
             ) : (
               <>
-                <span>{quota.title}</span>
+                <span>
+                  {quota.type === SignupStatus.IN_OPEN_QUOTA
+                    ? t("Avoin kiintiö")
+                    : quota.title}
+                </span>
                 {typeof quota.size === "number" ? (
                   <div className="relative">
                     <Progress


### PR DESCRIPTION
## Description

- Updated the SignUpQuotas component to display a localized "Avoin kiintiö" (Open Quota) label when the quota type is `SignupStatus.IN_OPEN_QUOTA`, instead of always displaying the quota title
- This ensures that open quotas are properly labeled with translated text rather than potentially empty or generic titles

### Before submitting the PR, please make sure you do the following

- [ ] If your PR is related to a previously discussed issue, please [link to it](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue) here.
- [x] Prefix your PR title with feat:, fix:, chore:, or docs:.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Make sure the commit history is linear, up-to-date with main branch and does not contain any erroneous changes

### Formatting and linting

- [ ] Format code with `pnpm format` and lint the project with `pnpm lint`