### PR TITLE
fix: downgrade to node 22 due to memory leak

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Base image with Node.js
-ARG NODE_VERSION=24.3.0
+ARG NODE_VERSION=22.22.0
 # Use a specific version of the Node.js Alpine image as the base. Alpine images are minimal and lightweight.
 FROM node:${NODE_VERSION}-alpine AS base
 # Update the package list and install libc6-compat. This package is often required for binary Node.js modules.

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "packageManager": "pnpm@10.16.1",
   "engines": {
-    "node": "24.5.0"
+    "node": "22.22.0"
   },
   "pnpm": {
     "onlyBuiltDependencies": [


### PR DESCRIPTION
- The production version is leaking memory (usage grows from 300mb to over 2gb)
- Downgrading to node 22 fixed similar issue in juvusivu (https://github.com/Tietokilta/juvusivu/pull/93), so it might fix it also here

<img width="949" height="309" alt="image" src="https://github.com/user-attachments/assets/4c1f1b16-1d76-4a22-a04d-96298fc7651f" />

### Before submitting the PR, please make sure you do the following

- [x] If your PR is related to a previously discussed issue, please [link to it](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue) here.
- [x] Prefix your PR title with feat:, fix:, chore:, or docs:.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Make sure the commit history is linear, up-to-date with main branch and does not contain any erroneous changes

### Formatting and linting

- [x] Format code with `pnpm format` and lint the project with `pnpm lint`
