### PR TITLE
Remove super old weekly newsletters link

### DIFF
--- a/apps/web/src/custom-pages/weekly-newsletter-page.tsx
+++ b/apps/web/src/custom-pages/weekly-newsletter-page.tsx
@@ -315,20 +315,6 @@ export default async function Page({ slug }: { slug?: string }) {
             {t("Read")}{" "}
             <a href={`/${locale}/${path}`}>{t("old weekly newsletters")}</a>
           </p>
-          <p>
-            {t("Read")}{" "}
-            <a
-              target="_blank"
-              href={
-                locale === "fi"
-                  ? `${legacyUrl}/arkisto/viikkomailit/`
-                  : `${legacyUrl}/arkisto/weekly_mails/`
-              }
-              rel="noopener"
-            >
-              {t("very old weekly newsletters")}
-            </a>
-          </p>
         </footer>
       </div>
     </main>

--- a/apps/web/src/emails/newsletter.tsx
+++ b/apps/web/src/emails/newsletter.tsx
@@ -32,7 +32,6 @@ export function Newsletter({
       read: "Read",
       path: "weekly-newsletters",
       "old-link": "old weekly newsletters",
-      "super-old-link": "very old weekly newsletters",
       summary: "Table of Contents",
     },
     fi: {
@@ -44,7 +43,6 @@ export function Newsletter({
       read: "Lue",
       path: "viikkotiedotteet",
       "old-link": "vanhoja viikkotiedotteita",
-      "super-old-link": "erittäin vanhoja viikkotiedotteita",
       summary: "Sisällysluettelo",
     },
   };
@@ -158,20 +156,6 @@ export function Newsletter({
         {t[locale].read}{" "}
         <a href={`${PUBLIC_FRONTEND_URL}/${locale}/${t[locale].path}`}>
           {t[locale]["old-link"]}
-        </a>
-      </p>
-      <p>
-        {t[locale].read}{" "}
-        <a
-          target="_blank"
-          href={
-            locale === "fi"
-              ? `${PUBLIC_LEGACY_URL}/arkisto/viikkomailit/`
-              : `${PUBLIC_LEGACY_URL}/arkisto/weekly_mails/`
-          }
-          rel="noopener"
-        >
-          {t[locale]["super-old-link"]}
         </a>
       </p>
     </div>

--- a/apps/web/src/locales/en.ts
+++ b/apps/web/src/locales/en.ts
@@ -238,7 +238,6 @@ const en = {
     "old weekly newsletters": "old weekly newsletters",
     Other: "Other",
     Read: "Read",
-    "very old weekly newsletters": "very old weekly newsletters",
     "This week": "This week",
     "Sign ups open this week": "Sign ups open this week",
     title: "Weekly newsletters",

--- a/apps/web/src/locales/fi.ts
+++ b/apps/web/src/locales/fi.ts
@@ -239,7 +239,6 @@ const fi = {
     "old weekly newsletters": "vanhoja viikkotiedotteita",
     Other: "Muu",
     Read: "Lue",
-    "very old weekly newsletters": "erittäin vanhoja viikkotiedotteita",
     "This week": "Tällä viikolla",
     "Sign ups open this week": "Tällä viikolla avoinna olevat ilmoittautumiset",
     title: "Viikkotiedotteet",


### PR DESCRIPTION
Remove the super old weekly newsletters link from the weekly news letters, as the destination of the link no longer works.
