### PR TITLE
fix: correct payment infoMessage + cleanup temporary strings

### DIFF
--- a/apps/web/src/locales/en.ts
+++ b/apps/web/src/locales/en.ts
@@ -180,13 +180,8 @@ const en = {
     },
     payment: {
       "Payment information": "Payment information",
-      "Payment instructions":
-        "Payments are handled on the event page. Use the button below to continue.",
-      "Go to payment page": "Go to payment page",
-      infoMessage:
-        "Payments are handled on the event page. Use the button below to continue.",
+      infoMessage: "Payment is done according to separate instructions.",
       pay: "Pay",
-      paymentPageHint: "Payment page: {paymentUrl}",
       status: {
         pending: ilmo["editSignup.payment.status.pending"],
         paid: ilmo["editSignup.payment.status.paid"],

--- a/apps/web/src/locales/fi.ts
+++ b/apps/web/src/locales/fi.ts
@@ -179,13 +179,8 @@ const fi = {
     },
     payment: {
       "Payment information": "Maksutiedot",
-      "Payment instructions":
-        "Maksu hoidetaan tapahtuman sivulla. Jatka alla olevasta painikkeesta.",
-      "Go to payment page": "Siirry maksusivulle",
-      infoMessage:
-        "Maksu hoidetaan tapahtuman sivulla. Jatka alla olevasta painikkeesta.",
+      infoMessage: "Maksaminen tapahtuu erillisten ohjeiden mukaisesti.",
       pay: "Maksa",
-      paymentPageHint: "Maksusivu: {paymentUrl}",
       status: {
         pending: ilmo["editSignup.payment.status.pending"],
         paid: ilmo["editSignup.payment.status.paid"],


### PR DESCRIPTION
## Description

- Updated infomessage that is shown for payments handled outside the ilmomasiina
- Removed unused (temporary) translation values

### Before submitting the PR, please make sure you do the following

- [x] If your PR is related to a previously discussed issue, please [link to it](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue) here.
- [x] Prefix your PR title with feat:, fix:, chore:, or docs:.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Make sure the commit history is linear, up-to-date with main branch and does not contain any erroneous changes

### Formatting and linting

- [x] Format code with `pnpm format` and lint the project with `pnpm lint`
