### PR TITLE
fix: do not reset signup form on error

### DIFF
--- a/apps/web/src/app/[locale]/(main)/signups/[signupId]/[signupEditToken]/signup-form.tsx
+++ b/apps/web/src/app/[locale]/(main)/signups/[signupId]/[signupEditToken]/signup-form.tsx
@@ -22,8 +22,14 @@ import {
 } from "@tietokilta/ui";
 import NextForm from "next/form";
 import { useRouter } from "next/navigation";
-import { useActionState, useEffect } from "react";
-import { useFormStatus } from "react-dom";
+import {
+  FormEvent,
+  startTransition,
+  useActionState,
+  useEffect,
+  useRef,
+} from "react";
+import { requestFormReset, useFormStatus } from "react-dom";
 import {
   useDeleteSignUpAction,
   useSaveSignUpAction,
@@ -260,6 +266,22 @@ function Form({
     !!event.registrationEndDate &&
     new Date(event.registrationEndDate) < new Date();
 
+  const formRef = useRef<HTMLFormElement>(null);
+
+  // Form submission handler that doesn't reset the form
+  // https://github.com/facebook/react/issues/29034#issuecomment-2143595195
+  // Similar is implemented for the invoice-generator in PR #652
+  const handleSubmit = (event: FormEvent) => {
+    if (!(event.target instanceof HTMLFormElement))
+      throw new Error("Form submission event target is not a form element");
+
+    event.preventDefault();
+    const formData = new FormData(event.target);
+    startTransition(() => {
+      formAction(formData);
+    });
+  };
+
   // On first render, scroll to top
   useEffect(() => {
     window.scrollTo({ top: 0, behavior: "instant" });
@@ -276,11 +298,20 @@ function Form({
     } else if (!!state?.success || !!state?.errors?._form) {
       document.querySelector("[data-form-status]")?.scrollIntoView();
     }
+
+    // Reset form on success (because it is not done automatically with handleSubmit)
+    if (state?.success && formRef.current) {
+      requestFormReset(formRef.current);
+    }
   }, [state]);
 
   return (
     <NextForm
-      action={formAction}
+      ref={formRef}
+      // Use `onSubmit` instead of `action` to prevent form reset
+      onSubmit={handleSubmit}
+      // `action` is a required prop anyway
+      action={() => undefined}
       noValidate={isAndroidFirefox}
       className="w-full max-w-prose space-y-4 overflow-x-clip rounded-md border-2 border-gray-900 p-4 py-6 shadow-solid md:px-6 md:py-8"
     >


### PR DESCRIPTION
## Description
Do not reset event signup form when ilmo returns error (e.g. validation error).

- Similar fix was previously applied to invoice-generator form (#652)
- This is especially relevant on mobile firefox, as there we don't have browser-based validation

### Before submitting the PR, please make sure you do the following

- [x] If your PR is related to a previously discussed issue, please [link to it](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue) here.
- [x] Prefix your PR title with feat:, fix:, chore:, or docs:.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Make sure the commit history is linear, up-to-date with main branch and does not contain any erroneous changes

### Formatting and linting

- [x] Format code with `pnpm format` and lint the project with `pnpm lint`
