### PR TITLE
fix(ilmomasiina): Don't filter out empty string checkbox answers

### DIFF
--- a/apps/web/src/lib/api/external/ilmomasiina/actions.ts
+++ b/apps/web/src/lib/api/external/ilmomasiina/actions.ts
@@ -70,13 +70,11 @@ export function useSaveSignUpAction() {
     const formEntries = [...formData.entries()].reduce<
       Record<string, string | string[]>
     >((acc, [key, value]) => {
-      if (
-        value instanceof File ||
-        value === "" ||
-        value.startsWith("$ACTION")
-      ) {
+      if (value instanceof File || value.startsWith("$ACTION")) {
         return acc;
       }
+      // Empty strings are valid answers — a checkbox question may declare an
+      // option with an empty label, and ticking it submits `""` as the value.
 
       if (key in acc) {
         acc[key] = [value].concat(acc[key]);


### PR DESCRIPTION
## Description

Wappucruise sign up was broken on the web ilmo frontend due to this

### Before submitting the PR, please make sure you do the following

- [x] If your PR is related to a previously discussed issue, please [link to it](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue) here.
- [x] Prefix your PR title with feat:, fix:, chore:, or docs:.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Make sure the commit history is linear, up-to-date with main branch and does not contain any erroneous changes

### Formatting and linting

- [x] Format code with `pnpm format` and lint the project with `pnpm lint`
