### PR TITLE
feat(infoscreen): show page title in header bar

### DIFF
--- a/apps/web/src/app/[locale]/(infoscreen)/infoscreen/layout.tsx
+++ b/apps/web/src/app/[locale]/(infoscreen)/infoscreen/layout.tsx
@@ -2,6 +2,7 @@
 import { Inter, Roboto_Mono } from "next/font/google";
 import React from "react";
 import { InfoScreenHeader } from "@components/infoscreen/infoscreen-header/index.tsx";
+import { InfoscreenTitleProvider } from "@components/infoscreen/infoscreen-header/title-context.tsx";
 import "../../globals.css";
 import { cn } from "@lib/utils.ts";
 
@@ -22,10 +23,12 @@ export default function ScreenLayout({
   return (
     <html lang="fi" className="h-full">
       <body className={cn(inter.variable, robotoMono.variable, "h-full")}>
-        <div className="flex h-full flex-col bg-gray-200 font-mono">
-          <InfoScreenHeader />
-          <div className="size-full">{children}</div>
-        </div>
+        <InfoscreenTitleProvider>
+          <div className="flex h-full flex-col bg-gray-200 font-mono">
+            <InfoScreenHeader />
+            <div className="size-full">{children}</div>
+          </div>
+        </InfoscreenTitleProvider>
       </body>
     </html>
   );

--- a/apps/web/src/app/[locale]/(infoscreen)/infoscreen/page.tsx
+++ b/apps/web/src/app/[locale]/(infoscreen)/infoscreen/page.tsx
@@ -2,38 +2,50 @@ import { isTruthy } from "remeda";
 import { CustomIframe } from "@components/infoscreen/custom-iframe";
 import EventListInfoscreen from "@components/infoscreen/events-list";
 import { HSLcombinedSchedule } from "@components/infoscreen/hsl-schedules";
-import InfoScreenSwitcher from "@components/infoscreen/infoscreen-switcher/index";
+import InfoScreenSwitcher, {
+  type InfoScreenItem,
+} from "@components/infoscreen/infoscreen-switcher/index";
 import { KanttiinitCombined } from "@components/infoscreen/kanttiinit";
 import { fetchInfoScreen } from "@lib/api/info-screen";
-import { getLocale } from "@locales/server";
+import { getLocale, getTranslations } from "@locales/server";
 
 export default async function InfoScreenContents() {
   const locale = await getLocale();
-  const infoScreenConfig = await fetchInfoScreen(locale)({});
-  if (!infoScreenConfig) {
-    return (
-      <InfoScreenSwitcher>
-        <KanttiinitCombined />
-        <EventListInfoscreen />
-        <HSLcombinedSchedule />
-      </InfoScreenSwitcher>
-    );
-  }
-  return (
-    <InfoScreenSwitcher>
-      {infoScreenConfig.showKanttiinit ? <KanttiinitCombined /> : null}
-      {infoScreenConfig.showEvents ? <EventListInfoscreen /> : null}
-      {infoScreenConfig.showHSL ? <HSLcombinedSchedule /> : null}
-      {infoScreenConfig.additionalIframes
-        ?.filter((iframe) => iframe.enabled)
-        .map((iframe, i) => (
-          <CustomIframe
-            url={iframe.IframeUrl}
-            title={iframe.IframeTitle}
-            key={iframe.id ?? i}
-          />
-        ))
-        .filter(isTruthy)}
-    </InfoScreenSwitcher>
-  );
+  const [tInfoscreen, tIlmo, infoScreenConfig] = await Promise.all([
+    getTranslations("infoscreen"),
+    getTranslations("ilmomasiina"),
+    fetchInfoScreen(locale)({}),
+  ]);
+
+  const showKanttiinit = infoScreenConfig?.showKanttiinit ?? true;
+  const showEvents = infoScreenConfig?.showEvents ?? true;
+  const showHSL = infoScreenConfig?.showHSL ?? true;
+
+  const iframeItems: InfoScreenItem[] =
+    infoScreenConfig?.additionalIframes
+      ?.filter((iframe) => iframe.enabled)
+      .map((iframe) => ({
+        title: iframe.IframeTitle,
+        content: (
+          <CustomIframe url={iframe.IframeUrl} title={iframe.IframeTitle} />
+        ),
+      })) ?? [];
+
+  const items: InfoScreenItem[] = [
+    showKanttiinit
+      ? { title: tInfoscreen("Menus"), content: <KanttiinitCombined /> }
+      : null,
+    showEvents
+      ? { title: tIlmo("Events"), content: <EventListInfoscreen /> }
+      : null,
+    showHSL
+      ? {
+          title: tInfoscreen("Aalto-university"),
+          content: <HSLcombinedSchedule />,
+        }
+      : null,
+    ...iframeItems,
+  ].filter(isTruthy);
+
+  return <InfoScreenSwitcher items={items} />;
 }

--- a/apps/web/src/components/infoscreen/events-list/index.tsx
+++ b/apps/web/src/components/infoscreen/events-list/index.tsx
@@ -9,7 +9,6 @@ export default async function EventListInfoscreen({
 }: {
   showIlmostatus?: boolean;
 }) {
-  const tIlmo = await getTranslations("ilmomasiina");
   const tCal = await getTranslations("calendar");
   const locale = await getLocale();
   const eventsResponse = await fetchUpcomingEvents(locale);
@@ -26,9 +25,6 @@ export default async function EventListInfoscreen({
 
   return (
     <main id="main" className="flex flex-col p-4 align-top">
-      <h1 className="mt-4 mb-2 text-center font-mono text-5xl font-bold">
-        {tIlmo("Events")}
-      </h1>
       <ul className="flex flex-row flex-wrap">
         {Object.entries(upcomingEventsDataByWeek)
           .filter(

--- a/apps/web/src/components/infoscreen/hsl-schedules/index.tsx
+++ b/apps/web/src/components/infoscreen/hsl-schedules/index.tsx
@@ -60,19 +60,13 @@ function HSLSchedule({ stop }: HSLScheduleProps) {
 
 export async function HSLcombinedSchedule() {
   const stopData = await HSLSchedules();
-  const t = await getTranslations("infoscreen");
 
   if (stopData.length === 0) {
     return null;
   }
   return (
     <div className="w-full flex-row justify-center">
-      <div className="flex w-full justify-center">
-        <h1 className="flex justify-center pt-4 text-4xl font-bold">
-          {t("Aalto-university")}
-        </h1>
-      </div>
-      <div className="flex w-full justify-between gap-4 p-8 pt-0">
+      <div className="flex w-full justify-between gap-4 p-8">
         {stopData.map((stop) => (
           <HSLSchedule
             key={stop.name + stop.type}

--- a/apps/web/src/components/infoscreen/infoscreen-header/index.tsx
+++ b/apps/web/src/components/infoscreen/infoscreen-header/index.tsx
@@ -2,10 +2,11 @@ import Image from "next/image";
 import { PartnerLogos } from "@components/partner-logos";
 import TiKLogo from "../../../assets/TiK-logo-white.png";
 import { InfoscreenClock } from "./clock";
+import { InfoscreenTitle } from "./title";
 
 export function InfoScreenHeader() {
   return (
-    <div className="flex h-32 justify-between bg-black p-4 text-white">
+    <div className="flex h-32 items-center justify-between bg-black p-4 text-white">
       <div className="flex h-24 space-y-2">
         <Image
           alt="Tietokilta"
@@ -15,6 +16,7 @@ export function InfoScreenHeader() {
         />
         <InfoscreenClock />
       </div>
+      <InfoscreenTitle />
       <div className="mx-10 flex h-24 space-y-2">
         <PartnerLogos
           statuses={["mainPartner"]}

--- a/apps/web/src/components/infoscreen/infoscreen-header/title-context.tsx
+++ b/apps/web/src/components/infoscreen/infoscreen-header/title-context.tsx
@@ -1,0 +1,30 @@
+"use client";
+import {
+  createContext,
+  useContext,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
+
+interface TitleContextValue {
+  title: string | null;
+  setTitle: (title: string | null) => void;
+}
+
+const TitleContext = createContext<TitleContextValue>({
+  title: null,
+  setTitle: () => {},
+});
+
+export function InfoscreenTitleProvider({ children }: { children: ReactNode }) {
+  const [title, setTitle] = useState<string | null>(null);
+  const value = useMemo(() => ({ title, setTitle }), [title]);
+  return (
+    <TitleContext.Provider value={value}>{children}</TitleContext.Provider>
+  );
+}
+
+export function useInfoscreenTitle() {
+  return useContext(TitleContext);
+}

--- a/apps/web/src/components/infoscreen/infoscreen-header/title.tsx
+++ b/apps/web/src/components/infoscreen/infoscreen-header/title.tsx
@@ -1,0 +1,14 @@
+"use client";
+import { useInfoscreenTitle } from "./title-context";
+
+export function InfoscreenTitle() {
+  const { title } = useInfoscreenTitle();
+  if (!title) {
+    return <div className="flex-1" />;
+  }
+  return (
+    <div className="flex flex-1 items-center justify-center px-4">
+      <h1 className="text-center font-mono text-4xl font-bold">{title}</h1>
+    </div>
+  );
+}

--- a/apps/web/src/components/infoscreen/infoscreen-switcher/index.tsx
+++ b/apps/web/src/components/infoscreen/infoscreen-switcher/index.tsx
@@ -1,31 +1,44 @@
 "use client";
 import { useRouter } from "next/navigation";
 import React, { useEffect, useState } from "react";
-import { isTruthy } from "remeda";
+import { useInfoscreenTitle } from "@components/infoscreen/infoscreen-header/title-context";
+
+export interface InfoScreenItem {
+  title: string;
+  content: React.ReactNode;
+}
 
 export default function InfoScreenSwitcher({
-  children,
+  items,
 }: {
-  children: React.ReactNode;
+  items: InfoScreenItem[];
 }) {
   const [current, setCurrent] = useState(0);
-  const childrenArray = React.Children.toArray(children).filter(isTruthy);
-  const count = childrenArray.length;
+  const count = items.length;
+  const activeIndex = count === 0 ? 0 : current % count;
+  const activeTitle = items[activeIndex]?.title ?? null;
   const router = useRouter();
+  const { setTitle } = useInfoscreenTitle();
 
   useEffect(() => {
-    const setNextChild = () => {
+    setTitle(activeTitle);
+    return () => {
+      setTitle(null);
+    };
+  }, [activeTitle, setTitle]);
+
+  useEffect(() => {
+    if (count === 0) return undefined;
+    const intervalId = setInterval(() => {
       setCurrent((prev) => (prev + 1) % count);
       router.refresh();
-    };
-    const intervalId = setInterval(setNextChild, 15000); // Change screen every x seconds
-
+    }, 15000); // Change screen every x seconds
     return () => {
       clearInterval(intervalId);
     };
   }, [count, router]);
 
-  if (childrenArray.length === 0) {
+  if (count === 0) {
     return (
       <div className="flex h-full flex-col">
         error, no info screen components functional
@@ -35,16 +48,16 @@ export default function InfoScreenSwitcher({
 
   return (
     <>
-      {childrenArray.map((child, index) => (
+      {items.map((item, index) => (
         <div
           key={index}
           style={{
-            display: index === current ? "block" : "none",
+            display: index === activeIndex ? "block" : "none",
             width: "100%",
             height: "100%",
           }}
         >
-          {child}
+          {item.content}
         </div>
       ))}
     </>

--- a/apps/web/src/components/infoscreen/kanttiinit/index.tsx
+++ b/apps/web/src/components/infoscreen/kanttiinit/index.tsx
@@ -43,11 +43,6 @@ export async function KanttiinitCombined() {
   return (
     <div className="h-full">
       <div className="h-[95%] w-full flex-row justify-center">
-        <div className="flex w-full justify-center">
-          <h1 className="mt-2 mb-1 text-center font-mono text-5xl font-bold">
-            {t("Menus")}
-          </h1>
-        </div>
         <div className="top-3 flex w-full justify-between gap-x-4 gap-y-2 p-3 pt-0">
           {menus.map((menu) => (
             <div


### PR DESCRIPTION
## Description

- Infoscreen page titles are now shown in the header
- Custom iframe infoscreen titles are now shown too (weren't shown previously)

Closes #731 

### Before submitting the PR, please make sure you do the following

- [x] If your PR is related to a previously discussed issue, please [link to it](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue) here.
- [x] Prefix your PR title with feat:, fix:, chore:, or docs:.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Make sure the commit history is linear, up-to-date with main branch and does not contain any erroneous changes

### Formatting and linting

- [x] Format code with `pnpm format` and lint the project with `pnpm lint`
