### PR TITLE
fix: re-introduce image caption editing

### DIFF
--- a/apps/web/src/payload.config.ts
+++ b/apps/web/src/payload.config.ts
@@ -5,6 +5,7 @@ import {
   lexicalEditor,
   LinkFeature,
   RelationshipFeature,
+  UploadFeature,
 } from "@payloadcms/richtext-lexical";
 import { azureStorage } from "@payloadcms/storage-azure";
 import { buildConfig } from "payload";
@@ -155,7 +156,22 @@ export default buildConfig({
           Collapsible,
         ],
       }),
-      // UploadFeature({})
+      UploadFeature({
+        collections: {
+          media: {
+            fields: [
+              {
+                name: "caption",
+                label: "Caption",
+                localized: true,
+                type: "text",
+                minLength: 20,
+                maxLength: 100,
+              },
+            ],
+          },
+        },
+      }),
     ],
   }),
   plugins: [


### PR DESCRIPTION
This was accidentally removed in the migration to payload v3

### Before submitting the PR, please make sure you do the following

- [x] If your PR is related to a previously discussed issue, please [link to it](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue) here.
- [x] Prefix your PR title with feat:, fix:, chore:, or docs:.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Make sure the commit history is linear, up-to-date with main branch and does not contain any erroneous changes

### Formatting and linting

- [x] Format code with `pnpm format` and lint the project with `pnpm lint`
