### PR TITLE
fix(news): bust landing-page cache on news edits

### DIFF
--- a/apps/web/src/app/(payload)/admin/importMap.js
+++ b/apps/web/src/app/(payload)/admin/importMap.js
@@ -1,10 +1,10 @@
 import { RscEntryLexicalCell as RscEntryLexicalCell_44fe37237e0ebf4470c9990d8cb7b07e } from '@payloadcms/richtext-lexical/rsc'
 import { RscEntryLexicalField as RscEntryLexicalField_44fe37237e0ebf4470c9990d8cb7b07e } from '@payloadcms/richtext-lexical/rsc'
 import { LexicalDiffComponent as LexicalDiffComponent_44fe37237e0ebf4470c9990d8cb7b07e } from '@payloadcms/richtext-lexical/rsc'
+import { UploadFeatureClient as UploadFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
 import { BlocksFeatureClient as BlocksFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
 import { InlineToolbarFeatureClient as InlineToolbarFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
 import { HorizontalRuleFeatureClient as HorizontalRuleFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
-import { UploadFeatureClient as UploadFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
 import { BlockquoteFeatureClient as BlockquoteFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
 import { RelationshipFeatureClient as RelationshipFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
 import { LinkFeatureClient as LinkFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
@@ -33,10 +33,10 @@ export const importMap = {
   "@payloadcms/richtext-lexical/rsc#RscEntryLexicalCell": RscEntryLexicalCell_44fe37237e0ebf4470c9990d8cb7b07e,
   "@payloadcms/richtext-lexical/rsc#RscEntryLexicalField": RscEntryLexicalField_44fe37237e0ebf4470c9990d8cb7b07e,
   "@payloadcms/richtext-lexical/rsc#LexicalDiffComponent": LexicalDiffComponent_44fe37237e0ebf4470c9990d8cb7b07e,
+  "@payloadcms/richtext-lexical/client#UploadFeatureClient": UploadFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
   "@payloadcms/richtext-lexical/client#BlocksFeatureClient": BlocksFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
   "@payloadcms/richtext-lexical/client#InlineToolbarFeatureClient": InlineToolbarFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
   "@payloadcms/richtext-lexical/client#HorizontalRuleFeatureClient": HorizontalRuleFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  "@payloadcms/richtext-lexical/client#UploadFeatureClient": UploadFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
   "@payloadcms/richtext-lexical/client#BlockquoteFeatureClient": BlockquoteFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
   "@payloadcms/richtext-lexical/client#RelationshipFeatureClient": RelationshipFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
   "@payloadcms/richtext-lexical/client#LinkFeatureClient": LinkFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,

--- a/apps/web/src/collections/news.ts
+++ b/apps/web/src/collections/news.ts
@@ -1,6 +1,7 @@
 import type { CollectionConfig } from "payload";
 import { signedIn } from "../access/signed-in";
 import { revalidateCollection } from "../hooks/revalidate-collection";
+import { revalidateLandingPageAnnouncement } from "../hooks/revalidate-landing-page-announcement";
 
 export const News: CollectionConfig = {
   slug: "news",
@@ -111,6 +112,9 @@ export const News: CollectionConfig = {
     },
   ],
   hooks: {
-    afterChange: [revalidateCollection("news")],
+    afterChange: [
+      revalidateCollection("news"),
+      revalidateLandingPageAnnouncement,
+    ],
   },
 };

--- a/apps/web/src/hooks/revalidate-landing-page-announcement.ts
+++ b/apps/web/src/hooks/revalidate-landing-page-announcement.ts
@@ -1,0 +1,15 @@
+// Bust the landing-page caches whenever any news item changes.
+
+import { revalidatePath, revalidateTag } from "next/cache";
+import type { CollectionAfterChangeHook } from "payload";
+
+export const revalidateLandingPageAnnouncement: CollectionAfterChangeHook = ({
+  doc,
+  req,
+}) => {
+  req.payload.logger.info("revalidating landing-page announcement");
+  revalidateTag("global-landing-page", "default");
+  revalidatePath("/[locale]", "layout");
+
+  return doc;
+};


### PR DESCRIPTION
The landing page caches the `landing-page` global under the `global-landing-page` tag with `revalidate: false`. The announcement is a `news` item embedded in that cached global, but editing the news item only revalidated the `collection-news` tag, never `global-landing-page`. So the landing page kept serving a stale announcement (e.g. the pre-translation Finnish fallback on /en) until the global itself changed.

Add a `revalidateLandingPageAnnouncement` afterChange hook to the news collection that busts `global-landing-page` and the `/[locale]` layout, mirroring the existing `revalidateGlobal` wiring.


### Before submitting the PR, please make sure you do the following

- [x] If your PR is related to a previously discussed issue, please [link to it](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue) here.
- [x] Prefix your PR title with feat:, fix:, chore:, or docs:.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Make sure the commit history is linear, up-to-date with main branch and does not contain any erroneous changes

### Formatting and linting

- [x] Format code with `pnpm format` and lint the project with `pnpm lint`
