### PR TITLE
feat: add columns block to display text side-by-side

### DIFF
--- a/apps/web/src/blocks/columns.ts
+++ b/apps/web/src/blocks/columns.ts
@@ -1,0 +1,24 @@
+import { lexicalEditor } from "@payloadcms/richtext-lexical";
+import type { Block } from "payload";
+
+export const Columns = {
+  slug: "columns",
+  fields: [
+    {
+      name: "columns",
+      type: "array",
+      required: true,
+      minRows: 2,
+      labels: { singular: "Column", plural: "Columns" },
+      fields: [
+        {
+          name: "content",
+          type: "richText",
+          editor: lexicalEditor({}),
+          required: true,
+          localized: true,
+        },
+      ],
+    },
+  ],
+} satisfies Block;

--- a/apps/web/src/components/columns-block/index.tsx
+++ b/apps/web/src/components/columns-block/index.tsx
@@ -1,0 +1,26 @@
+import type { CSSProperties, JSX } from "react";
+import type { ColumnsBlockNode, Node } from "@lexical-types";
+
+interface ColumnsBlockProps {
+  columns: ColumnsBlockNode["fields"]["columns"];
+  Renderer: React.ComponentType<{ nodes: Node[] }>;
+}
+
+export function ColumnsBlock({
+  columns,
+  Renderer,
+}: ColumnsBlockProps): JSX.Element {
+  const style: CSSProperties = {
+    gridTemplateColumns: `repeat(${columns.length}, minmax(0, 1fr))`,
+  };
+  return (
+    <div className="my-4 flex flex-col gap-6 md:grid" style={style}>
+      {columns.map((column, index) => (
+        // eslint-disable-next-line react/no-array-index-key -- stable order
+        <div key={column.id ?? index}>
+          <Renderer nodes={column.content.root.children} />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/components/lexical/lexical-serializer.tsx
+++ b/apps/web/src/components/lexical/lexical-serializer.tsx
@@ -17,6 +17,7 @@ import {
 } from "../../lib/utils";
 import { BoardGrid } from "../board-grid";
 import { CollapsibleBlock } from "../collapsible-block";
+import { ColumnsBlock } from "../columns-block";
 import { CommitteeCard } from "../committee-card";
 import { CommitteeList } from "../committee-list";
 import { EditorInChief } from "../editor-in-chief";
@@ -343,6 +344,14 @@ function Block({ node }: { node: BlockNode }) {
         <CollapsibleBlock
           header={node.fields.header}
           content={node.fields.content.root.children}
+          Renderer={LexicalSerializer}
+        />
+      );
+    }
+    case "columns": {
+      return (
+        <ColumnsBlock
+          columns={node.fields.columns}
           Renderer={LexicalSerializer}
         />
       );

--- a/apps/web/src/components/lexical/types.ts
+++ b/apps/web/src/components/lexical/types.ts
@@ -228,6 +228,16 @@ export type CollapsibleBlockNode = BaseBlockNode & {
   };
 };
 
+export type ColumnsBlockNode = BaseBlockNode & {
+  fields: BaseBlockFields & {
+    blockType: "columns";
+    columns: {
+      content: EditorState;
+      id?: string | null;
+    }[];
+  };
+};
+
 export type BlockNode =
   | CommitteesYearBlockNode
   | ImageLinkGridBlockNode
@@ -236,7 +246,8 @@ export type BlockNode =
   | EditorInChiefBlockNode
   | InvoiceGeneratorBlockNode
   | PartnersBlockNode
-  | CollapsibleBlockNode;
+  | CollapsibleBlockNode
+  | ColumnsBlockNode;
 
 export type Node =
   | TextNode

--- a/apps/web/src/lib/utils.ts
+++ b/apps/web/src/lib/utils.ts
@@ -61,6 +61,46 @@ export interface TocItem {
   id: string;
 }
 
+const collectHeadings = (
+  nodes: Node[],
+  toc: TocItem[],
+  seenIds: Map<string, number>,
+  onlyTopLevel: boolean,
+): void => {
+  for (const node of nodes) {
+    if (node.type === "heading" && (node.tag === "h2" || node.tag === "h3")) {
+      const level = parseInt(node.tag[1], 10) as 2 | 3;
+      if (onlyTopLevel && level === 3) continue;
+
+      const text = lexicalNodeToTextContent(node);
+      const baseId = stringToId(text);
+      const id = makeUniqueId(baseId, seenIds);
+
+      toc.push({ text, level, id });
+    } else if (node.type === "block") {
+      walkBlockFields(node.fields, toc, seenIds, onlyTopLevel);
+    }
+  }
+};
+
+const walkBlockFields = (
+  value: unknown,
+  toc: TocItem[],
+  seenIds: Map<string, number>,
+  onlyTopLevel: boolean,
+): void => {
+  if (!value || typeof value !== "object") return;
+  const maybeRoot = (value as { root?: { children?: unknown } }).root;
+  if (maybeRoot && Array.isArray(maybeRoot.children)) {
+    collectHeadings(maybeRoot.children as Node[], toc, seenIds, onlyTopLevel);
+    return;
+  }
+  const children = Array.isArray(value) ? value : Object.values(value);
+  for (const child of children) {
+    walkBlockFields(child, toc, seenIds, onlyTopLevel);
+  }
+};
+
 export const generateTocFromRichText = (
   content?: EditorState,
   onlyTopLevel = false,
@@ -68,27 +108,7 @@ export const generateTocFromRichText = (
   if (!content) return [];
   const toc: TocItem[] = [];
   const seenIds = new Map<string, number>();
-
-  for (const node of content.root.children) {
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- extra safety
-    if (node.type === "heading" && (node.tag === "h2" || node.tag === "h3")) {
-      const tag = node.tag;
-      const level = parseInt(tag[1], 10) as 2 | 3;
-
-      if (onlyTopLevel && level === 3) continue;
-
-      const text = lexicalNodeToTextContent(node);
-      const baseId = stringToId(text);
-      const id = makeUniqueId(baseId, seenIds);
-
-      toc.push({
-        text,
-        level,
-        id,
-      });
-    }
-  }
-
+  collectHeadings(content.root.children, toc, seenIds, onlyTopLevel);
   return toc;
 };
 

--- a/apps/web/src/payload.config.ts
+++ b/apps/web/src/payload.config.ts
@@ -13,6 +13,7 @@ import { OAuth2Plugin, defaultGetToken } from "payload-oauth2";
 import sharp from "sharp";
 import type { Config } from "@payload-types";
 import { Collapsible } from "./blocks/collapsible";
+import { Columns } from "./blocks/columns";
 import { CommitteesInYear } from "./blocks/committees-in-year";
 import { EditorInChief } from "./blocks/editor-in-chief";
 import { GoogleForm } from "./blocks/google-form";
@@ -154,6 +155,7 @@ export default buildConfig({
           InvoiceGenerator,
           PartnersBlock,
           Collapsible,
+          Columns,
         ],
       }),
       UploadFeature({


### PR DESCRIPTION
## Description

Adds a new block type for creating side-by-side rich text sections

~~Also contains a minor version bump for payload, current version contains a bug which causes focus to constantly bump out of nested rich text editors. Mentioned in Payload v3.85 [release notes](https://github.com/payloadcms/payload/releases#release-v3.85.0)~~ Already bumped in main

demo:
<img width="1143" height="762" alt="image" src="https://github.com/user-attachments/assets/5e6cf0a3-077b-4f40-a638-45cbbfab1e57" />


### Before submitting the PR, please make sure you do the following

- [x] If your PR is related to a previously discussed issue, please [link to it](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue) here.
- [x] Prefix your PR title with feat:, fix:, chore:, or docs:.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Make sure the commit history is linear, up-to-date with main branch and does not contain any erroneous changes

### Formatting and linting

- [x] Format code with `pnpm format` and lint the project with `pnpm lint`
